### PR TITLE
provide single argument to importlib.resources.files

### DIFF
--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -19,7 +19,7 @@ else:
     _extension = "so"
 
 _LIB = ctypes.CDLL(
-    str(files("coreforecast").joinpath("lib", _prefix, f"libcoreforecast.{_extension}"))
+    str(files("coreforecast") / "lib" / _prefix / f"libcoreforecast.{_extension}")
 )
 
 
@@ -69,10 +69,8 @@ class GroupedArray:
 
     def _pyfloat_to_c(self, x: float) -> Union[ctypes.c_float, ctypes.c_double]:
         if self.prefix == "GroupedArrayFloat32":
-            out = ctypes.c_float(x)
-        else:
-            out = ctypes.c_double(x)
-        return out
+            return ctypes.c_float(x)
+        return ctypes.c_double(x)
 
     def _scaler_fit(self, scaler_type: str) -> np.ndarray:
         stats = np.empty_like(self.data, shape=(len(self), 2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ cmake.verbose = true
 logging.level = "INFO"
 sdist.exclude = ["tests", "*.yml"]
 sdist.reproducible = true
-wheel.install-dir = ["coreforecast"]
+wheel.install-dir = "coreforecast"
 wheel.packages = ["coreforecast"]
 wheel.py-api = "py3"
 


### PR DESCRIPTION
Combines the path to the shared library using "/" instead of joinpath.