### PR TITLE
add boxcox

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(APPLE)
 endif()
 
 if(UNIX)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fPIC -O0 -g -Wall -Wextra -Wpedantic")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC -O3 -Wall -Wextra -Wpedantic")
 else()
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2 /Ob2 /Ot /Oy /W4")

--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ exp_mean = ExpandingMean(lag=1).transform(ga)
 scaler = LocalStandardScaler().fit(ga)
 standardized = scaler.transform(ga)
 ```
+
+### Single-array functions
+We've also implemented the following functions that work on single arrays:
+
+* [boxcox_lambda](https://nixtlaverse.nixtla.io/coreforecast/scalers#function-boxcox-lambda)
+* [boxcox](https://nixtlaverse.nixtla.io/coreforecast/scalers#function-boxcox)
+* [inv_boxcox](https://nixtlaverse.nixtla.io/coreforecast/scalers#function-inv-boxcox)

--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -52,7 +52,7 @@ class GroupedArray:
         self.data = _ensure_float(data)
         if self.data.dtype == np.float32:
             self.prefix = "GroupedArrayFloat32"
-        elif self.data.dtype == np.float64:
+        else:
             self.prefix = "GroupedArrayFloat64"
         if indptr.dtype != np.int32:
             indptr = indptr.astype(np.int32)
@@ -323,7 +323,7 @@ class GroupedArray:
     def _boxcox_fit(
         self, season_length: int, lower: float, upper: float, method: str
     ) -> np.ndarray:
-        out = np.empty_like(self.data, shape=(len(self), 1))
+        out = np.empty_like(self.data, shape=(len(self), 2))
         _LIB[f"{self.prefix}_BoxCoxLambda{method}"](
             self._handle,
             ctypes.c_int(season_length),
@@ -331,8 +331,7 @@ class GroupedArray:
             _pyfloat_to_np_c(upper, self.data.dtype),
             _data_as_void_ptr(out),
         )
-        # dummy scales to be compatible with GroupedArray's ScalerTransform
-        return np.hstack([out, np.ones_like(out)])
+        return out
 
     def _boxcox_transform(self, stats: np.ndarray) -> np.ndarray:
         out = np.empty_like(self.data)

--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -27,6 +27,12 @@ def _data_as_void_ptr(arr: np.ndarray):
     return arr.ctypes.data_as(ctypes.POINTER(ctypes.c_void_p))
 
 
+def _ensure_float(x: np.ndarray) -> np.ndarray:
+    if x.dtype not in (np.float32, np.float64):
+        return x.astype(np.float32)
+    return x
+
+
 class GroupedArray:
     """Array of grouped data
 
@@ -37,14 +43,11 @@ class GroupedArray:
 
     def __init__(self, data: np.ndarray, indptr: np.ndarray, num_threads: int = 1):
         data = np.ascontiguousarray(data, dtype=data.dtype)
-        if data.dtype == np.float32:
+        self.data = _ensure_float(data)
+        if self.data.dtype == np.float32:
             self.prefix = "GroupedArrayFloat32"
-        elif data.dtype == np.float64:
+        elif self.data.dtype == np.float64:
             self.prefix = "GroupedArrayFloat64"
-        else:
-            self.prefix = "GroupedArrayFloat32"
-            data = data.astype(np.float32)
-        self.data = data
         if indptr.dtype != np.int32:
             indptr = indptr.astype(np.int32)
         self.indptr = indptr

--- a/coreforecast/scalers.py
+++ b/coreforecast/scalers.py
@@ -18,7 +18,7 @@ __all__ = [
     "LocalStandardScaler",
     "boxcox",
     "boxcox_lambda",
-    "inv_boxcox"
+    "inv_boxcox",
 ]
 
 
@@ -33,7 +33,7 @@ def boxcox_lambda(
     upper: float = 2.0,
     method: str = "guerrero",
 ) -> float:
-    """Find optimum lambda for the Box-Cox transformation
+    """Find optimum lambda for the Box-Cox transformation (supports negative numbers)
 
     Args:
         x (np.ndarray): Array with data to transform.

--- a/coreforecast/scalers.py
+++ b/coreforecast/scalers.py
@@ -1,13 +1,52 @@
+import ctypes
+
 import numpy as np
 
-from .grouped_array import GroupedArray
+from .grouped_array import _LIB, GroupedArray
 
 
 __all__ = [
+    "boxcox_lambda",
     "LocalMinMaxScaler",
     "LocalStandardScaler",
     "LocalRobustScaler",
 ]
+
+
+_LIB.BoxCoxLambda_Guerrero.restype = ctypes.c_double
+
+
+def boxcox_lambda(
+    x: np.ndarray,
+    season_length: int,
+    lower: float = -1.0,
+    upper: float = 2.0,
+    method: str = "guerrero",
+) -> float:
+    """Find optimum lambda for the Box-Cox transformation
+
+    Args:
+        x (np.ndarray): Array with data to transform.
+        season_length (int): Length of the seasonal period.
+        lower (float): Lower bound for the lambda.
+        upper (float): Upper bound for the lambda.
+        method (str): Method to use. Valid options are 'guerrero'.
+
+    Returns:
+        float: Optimum lambda."""
+    if method != "guerrero":
+        raise NotImplementedError(f"Method {method} not implemented")
+    if any(x <= 0):
+        raise ValueError("All values in x must be positive")
+    if lower >= upper:
+        raise ValueError("lower must be less than upper")
+    return _LIB.BoxCoxLambda_Guerrero(
+        x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        ctypes.c_int(x.size),
+        ctypes.c_int(season_length),
+        ctypes.c_double(lower),
+        ctypes.c_double(upper),
+    )
 
 
 class _BaseLocalScaler:

--- a/include/brent.h
+++ b/include/brent.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cmath>
+
+constexpr double GOLDEN_RATIO = 0.3819660;
+
+template <typename Function, typename... Args>
+double Brent(Function f, double a, double b, double tol, Args... args) {
+  double d, e, p, q, r, u, v, w, x;
+  double t2, fu, fv, fw, fx, xm, eps, tol1, tol3;
+
+  eps = std::numeric_limits<double>::epsilon();
+  tol1 = eps + 1.0;
+  eps = std::sqrt(eps);
+
+  v = a + GOLDEN_RATIO * (b - a);
+  w = v;
+  x = v;
+
+  d = 0.0;
+  e = 0.0;
+  fx = f(x, args...);
+  fv = fx;
+  fw = fx;
+  tol3 = tol / 3.0;
+
+  while (true) {
+    xm = (a + b) * 0.5;
+    tol1 = eps * std::abs(x) + tol3;
+    t2 = tol1 * 2.0;
+
+    if (std::abs(x - xm) <= t2 - (b - a) * 0.5) {
+      break;
+    }
+
+    p = 0.0;
+    q = 0.0;
+    r = 0.0;
+    if (std::abs(e) > tol1) {
+      r = (x - w) * (fx - fv);
+      q = (x - v) * (fx - fw);
+      p = (x - v) * q - (x - w) * r;
+      q = (q - r) * 2.0;
+      if (q > 0.0) {
+        p = -p;
+      } else {
+        q = -q;
+      }
+      r = e;
+      e = d;
+    }
+
+    if (std::abs(p) >= std::abs(q * 0.5 * r) || p <= q * (a - x) ||
+        p >= q * (b - x)) {
+      if (x < xm) {
+        e = b - x;
+      } else {
+        e = a - x;
+      }
+      d = GOLDEN_RATIO * e;
+    } else {
+      d = p / q;
+      u = x + d;
+      if (u - a < t2 || b - u < t2) {
+        d = tol1;
+        if (x >= xm) {
+          d = -d;
+        }
+      }
+    }
+
+    if (std::abs(d) >= tol1) {
+      u = x + d;
+    } else if (d > 0.0) {
+      u = x + tol1;
+    } else {
+      u = x - tol1;
+    }
+
+    fu = f(u, args...);
+
+    if (fu <= fx) {
+      if (u < x) {
+        b = x;
+      } else {
+        a = x;
+      }
+      v = w;
+      w = x;
+      x = u;
+      fv = fw;
+      fw = fx;
+      fx = fu;
+    } else {
+      if (u < x) {
+        a = u;
+      } else {
+        b = u;
+      }
+      if (fu <= fw || w == x) {
+        v = w;
+        fv = fw;
+        w = u;
+        fw = fu;
+      } else if (fu <= fv || v == x || v == w) {
+        v = u;
+        fv = fu;
+      }
+    }
+  }
+  return x;
+}

--- a/include/grouped_array.h
+++ b/include/grouped_array.h
@@ -86,7 +86,7 @@ public:
         scale = static_cast<T>(1.0);
       }
       for (indptr_t j = start; j < end; ++j) {
-        out[j] = f(data_[j], scale, offset);
+        out[j] = f(data_[j], offset, scale);
       }
     }
   }

--- a/include/scalers.h
+++ b/include/scalers.h
@@ -39,4 +39,7 @@ GroupedArrayFloat32_ScalerInverseTransform(GroupedArrayHandle handle,
 DLL_EXPORT int
 GroupedArrayFloat64_ScalerInverseTransform(GroupedArrayHandle handle,
                                            const double *stats, double *out);
+
+DLL_EXPORT double BoxCoxLambda_Guerrero(const double *x, int n, int period,
+                                        double lower, double upper);
 }

--- a/include/scalers.h
+++ b/include/scalers.h
@@ -4,6 +4,22 @@
 #include "grouped_array.h"
 
 extern "C" {
+DLL_EXPORT float Float32_BoxCoxLambdaGuerrero(const float *x, int n, int period,
+                                              float lower, float upper);
+DLL_EXPORT double Float64_BoxCoxLambdaGuerrero(const double *x, int n,
+                                               int period, double lower,
+                                               double upper);
+
+DLL_EXPORT void Float32_BoxCoxTransform(const float *x, int n, float lambda,
+                                        float *out);
+DLL_EXPORT void Float64_BoxCoxTransform(const double *x, int n, double lambda,
+                                        double *out);
+
+DLL_EXPORT void Float32_BoxCoxInverseTransform(const float *x, int n,
+                                               float lambda, float *out);
+DLL_EXPORT void Float64_BoxCoxInverseTransform(const double *x, int n,
+                                               double lambda, double *out);
+
 DLL_EXPORT int GroupedArrayFloat32_MinMaxScalerStats(GroupedArrayHandle handle,
                                                      float *out);
 DLL_EXPORT int GroupedArrayFloat64_MinMaxScalerStats(GroupedArrayHandle handle,
@@ -40,6 +56,26 @@ DLL_EXPORT int
 GroupedArrayFloat64_ScalerInverseTransform(GroupedArrayHandle handle,
                                            const double *stats, double *out);
 
-DLL_EXPORT double BoxCoxLambda_Guerrero(const double *x, int n, int period,
-                                        double lower, double upper);
+DLL_EXPORT int
+GroupedArrayFloat32_BoxCoxLambdaGuerrero(GroupedArrayHandle handle, int period,
+                                         float lower, float upper, float *out);
+
+DLL_EXPORT int
+GroupedArrayFloat64_BoxCoxLambdaGuerrero(GroupedArrayHandle handle, int period,
+                                         double lower, double upper,
+                                         double *out);
+
+DLL_EXPORT int GroupedArrayFloat32_BoxCoxTransform(GroupedArrayHandle handle,
+                                                   const float *lambdas,
+                                                   float *out);
+DLL_EXPORT int GroupedArrayFloat64_BoxCoxTransform(GroupedArrayHandle handle,
+                                                   const double *lambdas,
+                                                   double *out);
+
+DLL_EXPORT int
+GroupedArrayFloat32_BoxCoxInverseTransform(GroupedArrayHandle handle,
+                                           const float *lambdas, float *out);
+DLL_EXPORT int
+GroupedArrayFloat64_BoxCoxInverseTransform(GroupedArrayHandle handle,
+                                           const double *lambdas, double *out);
 }

--- a/include/stats.h
+++ b/include/stats.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <numeric>
 
 template <typename T> inline T Quantile(T *data, T p, int n) {
   T i_plus_g = p * (n - 1);
@@ -24,4 +25,21 @@ template <typename T> inline T SortedQuantile(T *data, T p, int n) {
     out += g * (data[i + 1] - out);
   }
   return out;
+}
+
+template <typename T> double Mean(const T *data, int n) {
+  double sum = std::accumulate(data, data + n, 0.0);
+  return sum / n;
+}
+
+template <typename T>
+double StandardDeviation(const T *data, int n, double mean, int ddof = 0) {
+  if (n <= ddof) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  double sum_sq = 0.0;
+  for (int i = 0; i < n; ++i) {
+    sum_sq += (data[i] - mean) * (data[i] - mean);
+  }
+  return std::sqrt(sum_sq / (n - ddof));
 }

--- a/src/scalers.cpp
+++ b/src/scalers.cpp
@@ -7,12 +7,12 @@
 #include <vector>
 
 template <typename T>
-inline T CommonScalerTransform(T data, T scale, T offset) {
+inline T CommonScalerTransform(T data, T offset, T scale) {
   return (data - offset) / scale;
 }
 
 template <typename T>
-inline T CommonScalerInverseTransform(T data, T scale, T offset) {
+inline T CommonScalerInverseTransform(T data, T offset, T scale) {
   return data * scale + offset;
 }
 
@@ -88,6 +88,16 @@ T GuerreroCV(T lambda, const std::vector<T> &x_mean,
 template <typename T>
 void BoxCoxLambda_Guerrero(const T *x, int n, T *out, int period, T lower,
                            T upper) {
+  if (n <= 2 * period) {
+    *out = static_cast<T>(1.0);
+    return;
+  }
+  for (int i = 0; i < n; ++i) {
+    if (x[i] <= 0.0) {
+      lower = std::max(lower, static_cast<T>(0.0));
+      break;
+    }
+  }
   int n_seasons = n / period;
   int n_full = n_seasons * period;
   // build matrix with subseries having full periods
@@ -136,7 +146,7 @@ template <typename T> inline T BoxCoxTransform(T x, T lambda, T /*unused*/) {
   if (x > 0) {
     return std::expm1(lambda * std::log(x)) / lambda;
   }
-  return -std::expm1(-lambda * std::log(-x)) / lambda;
+  return (-std::exp(lambda * std::log(-x)) - 1) / lambda;
 }
 
 template <typename T>

--- a/src/scalers.cpp
+++ b/src/scalers.cpp
@@ -284,14 +284,14 @@ int GroupedArrayFloat32_BoxCoxLambdaGuerrero(GroupedArrayHandle handle,
                                              int period, float lower,
                                              float upper, float *out) {
   auto ga = reinterpret_cast<GroupedArray<float> *>(handle);
-  ga->Reduce(BoxCoxLambda_Guerrero<float>, 1, out, 0, period, lower, upper);
+  ga->Reduce(BoxCoxLambda_Guerrero<float>, 2, out, 0, period, lower, upper);
   return 0;
 }
 int GroupedArrayFloat64_BoxCoxLambdaGuerrero(GroupedArrayHandle handle,
                                              int period, double lower,
                                              double upper, double *out) {
   auto ga = reinterpret_cast<GroupedArray<double> *>(handle);
-  ga->Reduce(BoxCoxLambda_Guerrero<double>, 1, out, 0, period, lower, upper);
+  ga->Reduce(BoxCoxLambda_Guerrero<double>, 2, out, 0, period, lower, upper);
   return 0;
 }
 

--- a/tests/test_lag_transforms.py
+++ b/tests/test_lag_transforms.py
@@ -97,6 +97,7 @@ combs_map = {
 @pytest.mark.parametrize("comb", list(combs_map.keys()))
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_correctness(data, comb, dtype):
+    atol = 1e-4
     rtol = 1e-5 if dtype == np.float32 else 1e-7
     if dtype == np.float32:
         if "rolling_std" in comb:
@@ -110,11 +111,11 @@ def test_correctness(data, comb, dtype):
     wres = transform(data, indptr, False, lag, wf, *args)
     cobj = cf(lag, *args)
     cres = cobj.transform(ga)
-    np.testing.assert_allclose(wres, cres, rtol=rtol)
+    np.testing.assert_allclose(wres, cres, atol=atol, rtol=rtol)
     # update
     wres = transform(data, indptr, True, lag - 1, wf, *args)
     cres = cobj.update(ga)
-    np.testing.assert_allclose(wres, cres, rtol=rtol)
+    np.testing.assert_allclose(wres, cres, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("window_type", ["rolling", "seasonal_rolling", "expanding"])

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -3,9 +3,13 @@ import pytest
 
 from coreforecast.grouped_array import GroupedArray
 from coreforecast.scalers import (
+    LocalBoxCoxScaler,
     LocalMinMaxScaler,
     LocalRobustScaler,
     LocalStandardScaler,
+    boxcox_lambda,
+    boxcox,
+    inv_boxcox,
 )
 
 
@@ -105,6 +109,24 @@ def test_correctness(data, indptr, scaler_name, dtype):
         ]
     )
     np.testing.assert_allclose(restored, expected_restored, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_boxcox_correctness(data, indptr, dtype):
+    ga = GroupedArray(data.astype(dtype), indptr)
+    sc = LocalBoxCoxScaler(season_length=10)
+    sc.fit(ga)
+    transformed = sc.transform(ga)
+    restored = sc.inverse_transform(GroupedArray(transformed, ga.indptr))
+    atol = 5e-4 if dtype == np.float32 else 1e-8
+    np.testing.assert_allclose(ga.data, restored, atol=atol)
+    lmbda = boxcox_lambda(ga[0], 10)
+    np.testing.assert_allclose(lmbda, sc.stats[0, 0])
+    first_grp = slice(indptr[0], indptr[1])
+    first_tfm = boxcox(ga[0], lmbda)
+    first_restored = inv_boxcox(first_tfm, lmbda)
+    np.testing.assert_allclose(first_tfm, transformed[first_grp])
+    np.testing.assert_allclose(first_restored, restored[first_grp])
 
 
 @pytest.mark.parametrize("scaler_name", scalers)

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -7,8 +7,8 @@ from coreforecast.scalers import (
     LocalMinMaxScaler,
     LocalRobustScaler,
     LocalStandardScaler,
-    boxcox_lambda,
     boxcox,
+    boxcox_lambda,
     inv_boxcox,
 )
 
@@ -113,7 +113,11 @@ def test_correctness(data, indptr, scaler_name, dtype):
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_boxcox_correctness(data, indptr, dtype):
-    ga = GroupedArray(data.astype(dtype), indptr)
+    data = data.astype(dtype, copy=True)
+    # introduce some nans
+    for i in [1, 90, 177]:
+        data[indptr[i] : indptr[i] + 19] = np.nan
+    ga = GroupedArray(data, indptr)
     sc = LocalBoxCoxScaler(season_length=10)
     sc.fit(ga)
     transformed = sc.transform(ga)


### PR DESCRIPTION
Adds functionality to find the optimum lambda of the Box-Cox transformation using the Guerrero[1] method as well as functions to perform and invert the transformation (with support for negative values). This is implemented as functions for single arrays as well as for the GroupedArray.

[1] Guerrero, V.M. (1993) Time-series analysis supported by power transformations. Journal of Forecasting, 12, 37–48.