### PR TITLE
add auto seasonality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ We've also implemented some functions that work on single arrays, you can refer 
 
 * [differences](https://nixtlaverse.nixtla.io/coreforecast/differences)
 * [scalers](https://nixtlaverse.nixtla.io/coreforecast/scalers)
+* [seasonal](https://nixtlaverse.nixtla.io/coreforecast/seasonal)

--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -34,7 +34,7 @@ class GroupedArray:
             ctypes.byref(self._handle),
         )
 
-    def with_data(self, data: np.ndarray) -> "GroupedArray":
+    def _with_data(self, data: np.ndarray) -> "GroupedArray":
         data = data.astype(self.data.dtype, copy=False)
         data = np.ascontiguousarray(data)
         return GroupedArray(data, self.indptr, self.num_threads)
@@ -79,7 +79,7 @@ class GroupedArray:
         )
         return out
 
-    def index_from_end(self, k: int) -> np.ndarray:
+    def _index_from_end(self, k: int) -> np.ndarray:
         out = np.empty_like(self.data, shape=len(self))
         _LIB[f"{self.prefix}_IndexFromEnd"](
             self._handle,

--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -106,6 +106,16 @@ class GroupedArray:
         )
         return out
 
+    def _tails(self, max_k: int, ks: np.ndarray) -> np.ndarray:
+        ks_and_tails = np.empty_like(self.data, shape=(len(self), max_k + 1))
+        ks_and_tails[:, 0] = ks
+        _LIB[f"{self.prefix}_Tails"](
+            self._handle,
+            ctypes.c_int(max_k),
+            _data_as_void_ptr(ks_and_tails),
+        )
+        return ks_and_tails[:, 1:].ravel()
+
     def _lag_transform(self, lag: int) -> np.ndarray:
         out = np.empty_like(self.data)
         _LIB[f"{self.prefix}_LagTransform"](
@@ -360,11 +370,39 @@ class GroupedArray:
         )
         return out
 
+    def _num_seas_diffs_periods(self, max_d: int, periods: np.ndarray) -> np.ndarray:
+        periods_and_out = np.empty_like(self.data, shape=(len(self), 2))
+        periods_and_out[:, 0] = periods
+        _LIB[f"{self.prefix}_NumSeasDiffsPeriods"](
+            self._handle,
+            ctypes.c_int(max_d),
+            _data_as_void_ptr(periods_and_out),
+        )
+        return periods_and_out[:, 1]
+
+    def _periods(self, max_period: int) -> np.ndarray:
+        out = np.empty_like(self.data, shape=len(self))
+        _LIB[f"{self.prefix}_Period"](
+            self._handle,
+            ctypes.c_size_t(max_period),
+            _data_as_void_ptr(out),
+        )
+        return out
+
     def _diff(self, d: int) -> np.ndarray:
         out = np.empty_like(self.data)
         _LIB[f"{self.prefix}_Difference"](
             self._handle,
             ctypes.c_int(d),
+            _data_as_void_ptr(out),
+        )
+        return out
+
+    def _diffs(self, ds: np.ndarray) -> np.ndarray:
+        out = np.empty_like(self.data)
+        _LIB[f"{self.prefix}_Differences"](
+            self._handle,
+            _data_as_void_ptr(ds),
             _data_as_void_ptr(out),
         )
         return out
@@ -375,6 +413,17 @@ class GroupedArray:
             self._handle,
             ctypes.c_int(d),
             _data_as_void_ptr(tails),
+            _data_as_void_ptr(out),
+        )
+        return out
+
+    def _inv_diffs(self, max_d: int, ds: np.ndarray, tails: np.ndarray) -> np.ndarray:
+        ds_and_tails = np.hstack([ds.reshape(-1, 1), tails.reshape(-1, max_d)])
+        out = np.empty_like(self.data)
+        _LIB[f"{self.prefix}_InvertDifferences"](
+            self._handle,
+            ctypes.c_int(max_d),
+            _data_as_void_ptr(ds_and_tails),
             _data_as_void_ptr(out),
         )
         return out

--- a/coreforecast/lag_transforms.py
+++ b/coreforecast/lag_transforms.py
@@ -63,7 +63,7 @@ class Lag(BaseLagTransform):
         return ga._lag_transform(self.lag)
 
     def update(self, ga: GroupedArray) -> np.ndarray:
-        return ga.index_from_end(self.lag - 1)
+        return ga._index_from_end(self.lag - 1)
 
 
 _rolling_base_docstring = """Rolling {stat_name}
@@ -294,7 +294,7 @@ class ExpandingMean(_ExpandingBase):
 
     def update(self, ga: GroupedArray) -> np.ndarray:
         self.n += 1
-        self.cumsum += ga.index_from_end(self.lag - 1)
+        self.cumsum += ga._index_from_end(self.lag - 1)
         return self.cumsum / self.n
 
 
@@ -308,7 +308,7 @@ class ExpandingStd(_ExpandingBase):
         return out
 
     def update(self, ga: GroupedArray) -> np.ndarray:
-        x = ga.index_from_end(self.lag - 1)
+        x = ga._index_from_end(self.lag - 1)
         self.stats[:, 0] += 1.0
         n = self.stats[:, 0]
         prev_avg = self.stats[:, 1].copy()
@@ -331,7 +331,7 @@ class _ExpandingComp(_ExpandingBase):
         return out
 
     def update(self, ga: GroupedArray) -> np.ndarray:
-        self.stats = self._comp_fn(self.stats, ga.index_from_end(self.lag - 1))
+        self.stats = self._comp_fn(self.stats, ga._index_from_end(self.lag - 1))
         return self.stats
 
 
@@ -388,6 +388,6 @@ class ExponentiallyWeightedMean(BaseLagTransform):
         return out
 
     def update(self, ga: GroupedArray) -> np.ndarray:
-        x = ga.index_from_end(self.lag - 1)
+        x = ga._index_from_end(self.lag - 1)
         self.ewm = self.alpha * x + (1 - self.alpha) * self.ewm
         return self.ewm

--- a/coreforecast/scalers.py
+++ b/coreforecast/scalers.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import Any, Optional, Union
+from typing import Optional
 
 import numpy as np
 
@@ -292,7 +292,7 @@ class AutoSeasonalDifferences:
         season_length (int): Length of the seasonal period.
         max_diffs (int): Maximum number of differences to apply.
         n_seasons (int | None): Number of seasons to use to determine the number of differences. Defaults to 10.
-            If `None` will use all samples, otherwise `season_length` * `n_seasons samples` will be used for the test.
+            If `None` will use all samples, otherwise `season_length` * `n_seasons` samples will be used for the test.
             Smaller values will be faster but could be less accurate.
     """
 
@@ -362,7 +362,7 @@ class AutoSeasonalityAndDifferences:
         max_season_length (int): Maximum length of the seasonal period.
         max_diffs (int): Maximum number of differences to apply.
         n_seasons (int | None): Number of seasons to use to determine the number of differences. Defaults to 10.
-            If `None` will use all samples, otherwise `max_season_length` * `n_seasons samples` will be used for the test.
+            If `None` will use all samples, otherwise `max_season_length` * `n_seasons` samples will be used for the test.
             Smaller values will be faster but could be less accurate.
     """
 
@@ -385,18 +385,18 @@ class AutoSeasonalityAndDifferences:
             np.ndarray: Array with the transformed data."""
         self.diffs_ = []
         self.tails_ = []
-        if self.n_seasons is None:
-            tails_ga = ga
-        else:
-            n_samples = self.max_season_length * self.n_seasons
-            tails_ga = GroupedArray(
-                ga._tail(n_samples),
-                np.arange(0, (len(ga) + 1) * n_samples, n_samples),
-                num_threads=ga.num_threads,
-            )
         transformed = ga.data.copy()
         for i in range(self.max_diffs):
             ga = ga.with_data(transformed)
+            if self.n_seasons is None:
+                tails_ga = ga
+            else:
+                n_samples = self.max_season_length * self.n_seasons
+                tails_ga = GroupedArray(
+                    ga._tail(n_samples),
+                    np.arange(0, (len(ga) + 1) * n_samples, n_samples),
+                    num_threads=ga.num_threads,
+                )
             periods = tails_ga._periods(self.max_season_length)
             self.diffs_.append(periods * tails_ga._num_seas_diffs_periods(1, periods))
             self.tails_.append(ga._tails(self.max_season_length, self.diffs_[i]))

--- a/coreforecast/scalers.py
+++ b/coreforecast/scalers.py
@@ -261,7 +261,7 @@ class AutoDifferences:
         transformed = ga.data.copy()
         dtype = ga.data.dtype.type
         for i in range(max_d):
-            ga = ga.with_data(transformed)
+            ga = ga._with_data(transformed)
             self.tails_.append(ga._tail(1))
             mask = np.where(self.diffs_ > i, dtype(1), dtype(0))
             transformed = ga._conditional_diff(1, mask)
@@ -279,7 +279,7 @@ class AutoDifferences:
         n_diffs = len(self.tails_)
         dtype = ga.data.dtype.type
         for i, tails in enumerate(self.tails_[::-1]):
-            ga = ga.with_data(transformed)
+            ga = ga._with_data(transformed)
             mask = np.where(self.diffs_ >= n_diffs - i, dtype(1), dtype(0))
             transformed = ga._conditional_inv_diff(1, mask, tails)
         return transformed
@@ -331,7 +331,7 @@ class AutoSeasonalDifferences:
         dtype = ga.data.dtype.type
         transformed = ga.data.copy()
         for i in range(max_d):
-            ga = ga.with_data(transformed)
+            ga = ga._with_data(transformed)
             self.tails_.append(ga._tail(self.season_length))
             mask = np.where(self.diffs_ > i, dtype(1), dtype(0))
             transformed = ga._conditional_diff(self.season_length, mask)
@@ -349,7 +349,7 @@ class AutoSeasonalDifferences:
         n_diffs = len(self.tails_)
         dtype = ga.data.dtype.type
         for i, tails in enumerate(self.tails_[::-1]):
-            ga = ga.with_data(transformed)
+            ga = ga._with_data(transformed)
             mask = np.where(self.diffs_ >= (n_diffs - i), dtype(1), dtype(0))
             transformed = ga._conditional_inv_diff(self.season_length, mask, tails)
         return transformed
@@ -387,7 +387,7 @@ class AutoSeasonalityAndDifferences:
         self.tails_ = []
         transformed = ga.data.copy()
         for i in range(self.max_diffs):
-            ga = ga.with_data(transformed)
+            ga = ga._with_data(transformed)
             if self.n_seasons is None:
                 tails_ga = ga
             else:
@@ -413,6 +413,6 @@ class AutoSeasonalityAndDifferences:
             np.ndarray: Array with the inverted transformation."""
         transformed = ga.data.copy()
         for diffs, tails in zip(self.diffs_[::-1], self.tails_[::-1]):
-            ga = ga.with_data(transformed)
+            ga = ga._with_data(transformed)
             transformed = ga._inv_diffs(self.max_season_length, diffs, tails)
         return transformed

--- a/coreforecast/seasonal.py
+++ b/coreforecast/seasonal.py
@@ -1,0 +1,28 @@
+import ctypes
+
+import numpy as np
+
+from ._lib import _LIB
+from .differences import num_seas_diffs
+from .utils import _data_as_void_ptr, _ensure_float, _float_arr_to_prefix
+
+
+_LIB.Float32_Period.restype = ctypes.c_int
+_LIB.Float64_Period.restype = ctypes.c_int
+
+
+def find_season_length(x: np.ndarray, max_season_length: int) -> int:
+    """Find the length of the seasonal period of the time series.
+    Returns 0 if no seasonality is found.
+
+    Args:
+        x (np.ndarray): Array with the time series.
+
+    Returns:
+        int: Season period."""
+    x = _ensure_float(x)
+    prefix = _float_arr_to_prefix(x)
+    period = getattr(_LIB, f"{prefix}_Period")(
+        _data_as_void_ptr(x), ctypes.c_size_t(x.size), ctypes.c_int(max_season_length)
+    )
+    return num_seas_diffs(x, period, 1) * period

--- a/docs/mintlify/mint.json
+++ b/docs/mintlify/mint.json
@@ -30,7 +30,8 @@
         "grouped_array",
         "lag_transforms",
         "scalers",
-        "differences"
+        "differences",
+        "seasonal"
       ]
     }
   ]

--- a/include/diff.h
+++ b/include/diff.h
@@ -3,18 +3,22 @@
 #include "export.h"
 #include "grouped_array.h"
 
+template <typename T> void Difference(const T *data, int n, T *out, int d) {
+  if (d == 0) {
+    std::copy(data, data + n, out);
+    return;
+  }
+  std::fill(out, out + d, std::numeric_limits<T>::quiet_NaN());
+  for (int i = d; i < n; ++i) {
+    out[i] = data[i] - data[i - d];
+  }
+}
+
 extern "C" {
 DLL_EXPORT void Float32_Difference(const float *x, indptr_t n, int d,
                                    float *out);
 DLL_EXPORT void Float64_Difference(const double *x, indptr_t n, int d,
                                    double *out);
-
-DLL_EXPORT void GroupedArrayFloat32_InvertDifference(GroupedArrayHandle handle,
-                                                     int d, float *tails,
-                                                     float *out);
-DLL_EXPORT void GroupedArrayFloat64_InvertDifference(GroupedArrayHandle handle,
-                                                     int d, double *tails,
-                                                     double *out);
 
 DLL_EXPORT int Float32_NumDiffs(const float *x, indptr_t n, int max_d);
 DLL_EXPORT int Float64_NumDiffs(const double *x, indptr_t n, int max_d);
@@ -23,6 +27,9 @@ DLL_EXPORT int Float32_NumSeasDiffs(const float *x, indptr_t n, int period,
                                     int max_d);
 DLL_EXPORT int Float64_NumSeasDiffs(const double *x, indptr_t n, int period,
                                     int max_d);
+
+DLL_EXPORT int Float32_Period(const float *x, size_t n, int period);
+DLL_EXPORT int Float64_Period(const double *x, size_t n, int period);
 
 DLL_EXPORT void GroupedArrayFloat32_NumDiffs(GroupedArrayHandle handle,
                                              int max_d, float *out);
@@ -36,10 +43,27 @@ DLL_EXPORT void GroupedArrayFloat64_NumSeasDiffs(GroupedArrayHandle handle,
                                                  int period, int max_d,
                                                  double *out);
 
+DLL_EXPORT void
+GroupedArrayFloat32_NumSeasDiffsPeriods(GroupedArrayHandle handle, int max_d,
+                                        float *periods_and_out);
+DLL_EXPORT void
+GroupedArrayFloat64_NumSeasDiffsPeriods(GroupedArrayHandle handle, int max_d,
+                                        double *periods_and_out);
+
+DLL_EXPORT void GroupedArrayFloat32_Period(GroupedArrayHandle handle,
+                                           size_t max_lag, float *out);
+DLL_EXPORT void GroupedArrayFloat64_Period(GroupedArrayHandle handle,
+                                           size_t max_lag, double *out);
+
 DLL_EXPORT void GroupedArrayFloat32_Difference(GroupedArrayHandle handle, int d,
                                                float *out);
 DLL_EXPORT void GroupedArrayFloat64_Difference(GroupedArrayHandle handle, int d,
                                                double *out);
+
+DLL_EXPORT void GroupedArrayFloat32_Differences(GroupedArrayHandle handle,
+                                                float *ds, float *out);
+DLL_EXPORT void GroupedArrayFloat64_Differences(GroupedArrayHandle handle,
+                                                double *ds, double *out);
 
 DLL_EXPORT void
 GroupedArrayFloat32_ConditionalDifference(GroupedArrayHandle handle, int period,
@@ -47,6 +71,22 @@ GroupedArrayFloat32_ConditionalDifference(GroupedArrayHandle handle, int period,
 DLL_EXPORT void
 GroupedArrayFloat64_ConditionalDifference(GroupedArrayHandle handle, int period,
                                           double *apply, double *out);
+
+DLL_EXPORT void GroupedArrayFloat32_InvertDifference(GroupedArrayHandle handle,
+                                                     int d, float *tails,
+                                                     float *out);
+DLL_EXPORT void GroupedArrayFloat64_InvertDifference(GroupedArrayHandle handle,
+                                                     int d, double *tails,
+                                                     double *out);
+
+DLL_EXPORT void GroupedArrayFloat32_InvertDifferences(GroupedArrayHandle handle,
+                                                      int max_d,
+                                                      float *d_and_tails,
+                                                      float *out);
+DLL_EXPORT void GroupedArrayFloat64_InvertDifferences(GroupedArrayHandle handle,
+                                                      int max_d,
+                                                      double *d_and_tails,
+                                                      double *out);
 
 DLL_EXPORT void GroupedArrayFloat32_ConditionalInvertDifference(
     GroupedArrayHandle handle, int period, float *apply_and_tails, float *out);

--- a/include/grouped_array_functions.h
+++ b/include/grouped_array_functions.h
@@ -18,12 +18,19 @@ DLL_EXPORT int GroupedArrayFloat32_IndexFromEnd(GroupedArrayHandle handle,
                                                 int k, float *out);
 DLL_EXPORT int GroupedArrayFloat64_IndexFromEnd(GroupedArrayHandle handle,
                                                 int k, double *out);
+
 DLL_EXPORT void GroupedArrayFloat32_Head(GroupedArrayHandle handle, int k,
                                          float *out);
 DLL_EXPORT void GroupedArrayFloat64_Head(GroupedArrayHandle handle, int k,
                                          double *out);
+
 DLL_EXPORT void GroupedArrayFloat32_Tail(GroupedArrayHandle handle, int k,
                                          float *out);
 DLL_EXPORT void GroupedArrayFloat64_Tail(GroupedArrayHandle handle, int k,
                                          double *out);
+
+DLL_EXPORT void GroupedArrayFloat32_Tails(GroupedArrayHandle handle, int max_k,
+                                          float *ks_and_out);
+DLL_EXPORT void GroupedArrayFloat64_Tails(GroupedArrayHandle handle, int max_k,
+                                          double *ks_and_out);
 }

--- a/include/kpss.h
+++ b/include/kpss.h
@@ -7,14 +7,6 @@
 #include <numeric>
 #include <vector>
 
-template <typename T> inline T Dot(const T *x, const T *y, size_t n) {
-  T result = 0.0;
-  for (size_t i = 0; i < n; ++i) {
-    result += x[i] * y[i];
-  }
-  return result;
-}
-
 template <typename T> T KPSS(const T *x, size_t n, size_t lags) {
   T mean = Mean(x, n);
   auto resids = std::vector<T>(n);

--- a/include/seasonal.h
+++ b/include/seasonal.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "diff.h"
 #include "export.h"
+#include "stats.h"
 #include "stl.hpp"
 
 #include <cmath>
@@ -28,13 +30,21 @@ template <typename T> T SeasHeuristic(const T *x, size_t n, size_t period) {
   return stl_fit.seasonal_strength();
 }
 
-extern "C" {
-DLL_EXPORT float Float32_SeasHeuristic(const float *x, size_t n,
-                                       size_t period) {
-  return SeasHeuristic(x, n, period);
-}
-DLL_EXPORT float Float64_SeasHeuristic(const double *x, size_t n,
-                                       size_t period) {
-  return SeasHeuristic(x, n, period);
-}
+template <typename T>
+void GreatestAutocovariance(const T *x, size_t n, T *out, size_t max_lag) {
+  T *resids = new T[n];
+  Difference(x, n, resids, 1);
+  indptr_t start = FirstNotNaN(resids, n);
+  max_lag = std::min(max_lag, n - start - 1);
+  T max_cov = -std::numeric_limits<T>::infinity();
+  size_t lag = 0;
+  for (size_t i = 2; i < max_lag + 1; ++i) {
+    T cov = Dot(resids + start, resids + start + i, n - start - i);
+    if (cov > max_cov) {
+      max_cov = cov;
+      lag = i;
+    }
+  }
+  delete[] resids;
+  *out = static_cast<T>(lag);
 }

--- a/include/stats.h
+++ b/include/stats.h
@@ -56,8 +56,3 @@ template <typename T> inline T Dot(const T *x, const T *y, size_t n) {
   }
   return result;
 }
-
-template <typename T>
-inline T Autocovariance(const T *x, size_t n, size_t lag) {
-  return Dot(x, x + lag, n - lag);
-}

--- a/include/stats.h
+++ b/include/stats.h
@@ -48,3 +48,16 @@ template <typename T>
 double StandardDeviation(const T *data, int n, double mean, int ddof = 0) {
   return std::sqrt(Variance<T>(data, n, mean, ddof));
 }
+
+template <typename T> inline T Dot(const T *x, const T *y, size_t n) {
+  T result = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    result += x[i] * y[i];
+  }
+  return result;
+}
+
+template <typename T>
+inline T Autocovariance(const T *x, size_t n, size_t lag) {
+  return Dot(x, x + lag, n - lag);
+}

--- a/src/diff.cpp
+++ b/src/diff.cpp
@@ -163,14 +163,14 @@ int Float64_NumSeasDiffs(const double *x, indptr_t n, int period, int max_d) {
   return static_cast<int>(out);
 }
 
-int Float32_Period(const float *x, size_t n, int period) {
+int Float32_Period(const float *x, size_t n, int max_lag) {
   float tmp;
-  GreatestAutocovariance(x, n, &tmp, period);
+  GreatestAutocovariance(x, n, &tmp, max_lag);
   return static_cast<int>(tmp);
 }
-int Float64_Period(const double *x, size_t n, int period) {
+int Float64_Period(const double *x, size_t n, int max_lag) {
   double tmp;
-  GreatestAutocovariance(x, n, &tmp, period);
+  GreatestAutocovariance(x, n, &tmp, max_lag);
   return static_cast<int>(tmp);
 }
 
@@ -207,13 +207,6 @@ void GroupedArrayFloat64_NumSeasDiffsPeriods(GroupedArrayHandle handle,
                                              double *periods_and_out) {
   auto ga = reinterpret_cast<GroupedArray<double> *>(handle);
   ga->Reduce(NumSeasDiffsPeriods<double>, 2, periods_and_out, 0, max_d);
-}
-
-void GroupedArrayFloat32_NumSeasDiffsWithPeriods(GroupedArrayHandle handle,
-                                                 int max_period, int max_d,
-                                                 float *out) {
-  auto ga = reinterpret_cast<GroupedArray<float> *>(handle);
-  ga->Reduce(NumSeasDiffs<float>, 1, out, 0, max_period, max_d);
 }
 
 void GroupedArrayFloat32_Period(GroupedArrayHandle handle, size_t max_lag,

--- a/src/grouped_array_functions.cpp
+++ b/src/grouped_array_functions.cpp
@@ -21,6 +21,12 @@ template <typename T> inline void Tail(const T *data, int n, T *out, int k) {
   std::copy(data + n - m, data + n, out + k - m);
 }
 
+template <typename T> inline void Tails(const T *data, int n, T *k_and_out) {
+  int k = static_cast<int>(k_and_out[0]);
+  T *out = k_and_out + 1;
+  Tail(data, n, out, k);
+}
+
 int GroupedArrayFloat32_Create(const float *data, indptr_t n_data,
                                indptr_t *indptr, indptr_t n_indptr,
                                int num_threads, GroupedArrayHandle *out) {
@@ -72,4 +78,15 @@ void GroupedArrayFloat32_Tail(GroupedArrayHandle handle, int k, float *out) {
 void GroupedArrayFloat64_Tail(GroupedArrayHandle handle, int k, double *out) {
   auto ga = reinterpret_cast<GroupedArray<double> *>(handle);
   ga->Reduce(Tail<double>, k, out, 0, k);
+}
+
+void GroupedArrayFloat32_Tails(GroupedArrayHandle handle, int max_k,
+                               float *ks_and_out) {
+  auto ga = reinterpret_cast<GroupedArray<float> *>(handle);
+  ga->Reduce(Tails<float>, 1 + max_k, ks_and_out, 0);
+}
+void GroupedArrayFloat64_Tails(GroupedArrayHandle handle, int max_k,
+                               double *ks_and_out) {
+  auto ga = reinterpret_cast<GroupedArray<double> *>(handle);
+  ga->Reduce(Tails<double>, 1 + max_k, ks_and_out, 0);
 }

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -3,10 +3,12 @@ import math
 import numpy as np
 import pytest
 
+from coreforecast.differences import diff
 from coreforecast.grouped_array import GroupedArray
 from coreforecast.scalers import (
     AutoDifferences,
     AutoSeasonalDifferences,
+    AutoSeasonalityAndDifferences,
     LocalBoxCoxScaler,
     LocalMinMaxScaler,
     LocalRobustScaler,
@@ -15,6 +17,7 @@ from coreforecast.scalers import (
     boxcox_lambda,
     inv_boxcox,
 )
+from coreforecast.seasonal import find_season_length
 
 
 @pytest.fixture
@@ -214,6 +217,30 @@ def test_seasonal_differences_correctness(data, indptr, dtype):
         expected2[horizon * i : horizon * (i + 1)] = np.tile(grp_tails, repeats)
     restored = sc.inverse_transform(preds_ga)
     np.testing.assert_allclose(restored, expected2)
+
+
+def test_seasonality_and_differences_correctness():
+    amplitudes = [3, 5]
+    seasonal_periods = [5, 24]
+    t = 1 + np.arange(500)
+    x = np.random.normal(t.size)
+    for amplitude, period in zip(amplitudes, seasonal_periods):
+        x += amplitude * np.cos(2 * np.pi * t / period)
+
+    period1 = find_season_length(x, 24)
+    y = diff(x, period1)
+    period2 = find_season_length(y, 24)
+    z = diff(y, period2)
+    period3 = find_season_length(z, 24)
+    assert period3 == 0
+    assert sorted([period1, period2]) == seasonal_periods
+
+    sc = AutoSeasonalityAndDifferences(
+        max_season_length=24, max_diffs=2, n_seasons=None
+    )
+    ga = GroupedArray(np.hstack([x, x]), np.array([0, x.size, 2 * x.size]))
+    diffed = sc.fit_transform(ga)
+    np.testing.assert_allclose(diffed, np.hstack([z, z]))
 
 
 @pytest.mark.parametrize("scaler_name", scalers)

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -241,6 +241,15 @@ def test_seasonality_and_differences_correctness():
     ga = GroupedArray(np.hstack([x, x]), np.array([0, x.size, 2 * x.size]))
     diffed = sc.fit_transform(ga)
     np.testing.assert_allclose(diffed, np.hstack([z, z]))
+    min_period = min(seasonal_periods)
+    zeros_ga = GroupedArray(
+        np.zeros(2 * min_period), np.array([0, min_period, 2 * min_period])
+    )
+    inv_transformed = sc.inverse_transform(zeros_ga)
+    inv_ga = zeros_ga._with_data(inv_transformed)
+    actual = np.hstack([inv_ga[0][:min_period], inv_ga[1][:min_period]])
+    expected = x[-period1:][:min_period] + y[-period2:][:min_period]
+    np.testing.assert_allclose(actual, np.hstack([expected, expected]))
 
 
 @pytest.mark.parametrize("scaler_name", scalers)


### PR DESCRIPTION
Adds functionality to detect the length of the seasonal period. Also adds the `AutoSeasonalityAndDifferences` scaler which detects the length of the seasonal period for each serie and takes that difference, with the possibility to take several differences in a row and thus remove several seasonalities.