### PR TITLE
add loglik method to boxcox

### DIFF
--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -343,7 +343,7 @@ class GroupedArray:
         self, season_length: Optional[int], lower: float, upper: float, method: str
     ) -> np.ndarray:
         out = np.empty_like(self.data, shape=(len(self), 2))
-        if method == "Guerrero":
+        if method == "guerrero":
             assert season_length is not None
             _LIB[f"{self.prefix}_BoxCoxLambdaGuerrero"](
                 self._handle,

--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -340,16 +340,25 @@ class GroupedArray:
         return out
 
     def _boxcox_fit(
-        self, season_length: int, lower: float, upper: float, method: str
+        self, season_length: Optional[int], lower: float, upper: float, method: str
     ) -> np.ndarray:
         out = np.empty_like(self.data, shape=(len(self), 2))
-        _LIB[f"{self.prefix}_BoxCoxLambda{method}"](
-            self._handle,
-            ctypes.c_int(season_length),
-            _pyfloat_to_np_c(lower, self.data.dtype),
-            _pyfloat_to_np_c(upper, self.data.dtype),
-            _data_as_void_ptr(out),
-        )
+        if method == "Guerrero":
+            assert season_length is not None
+            _LIB[f"{self.prefix}_BoxCoxLambdaGuerrero"](
+                self._handle,
+                ctypes.c_int(season_length),
+                _pyfloat_to_np_c(lower, self.data.dtype),
+                _pyfloat_to_np_c(upper, self.data.dtype),
+                _data_as_void_ptr(out),
+            )
+        else:
+            _LIB[f"{self.prefix}_BoxCoxLambdaLogLik"](
+                self._handle,
+                _pyfloat_to_np_c(lower, self.data.dtype),
+                _pyfloat_to_np_c(upper, self.data.dtype),
+                _data_as_void_ptr(out),
+            )
         return out
 
     def _boxcox_transform(self, stats: np.ndarray) -> np.ndarray:

--- a/coreforecast/grouped_array.py
+++ b/coreforecast/grouped_array.py
@@ -340,7 +340,7 @@ class GroupedArray:
         return out
 
     def _boxcox_fit(
-        self, season_length: Optional[int], lower: float, upper: float, method: str
+        self, method: str, season_length: Optional[int], lower: float, upper: float
     ) -> np.ndarray:
         out = np.empty_like(self.data, shape=(len(self), 2))
         if method == "guerrero":

--- a/coreforecast/scalers.py
+++ b/coreforecast/scalers.py
@@ -269,7 +269,10 @@ class LocalBoxCoxScaler(_BaseLocalScaler):
         if self.method == "loglik" and any(ga.data < 0):
             raise ValueError("All values in data must be positive for method='loglik'")
         self.stats_ = ga._boxcox_fit(
-            self.season_length, self.lower, self.upper, self.method
+            method=self.method,
+            season_length=self.season_length,
+            lower=self.lower,
+            upper=self.upper,
         )
         return self
 

--- a/include/brent.h
+++ b/include/brent.h
@@ -5,7 +5,7 @@
 constexpr double GOLDEN_RATIO = 0.3819660;
 
 template <typename Function, typename... Args>
-double Brent(Function f, double a, double b, double tol, Args... args) {
+double Brent(Function f, double a, double b, double tol, Args &&...args) {
   double d, e, p, q, r, u, v, w, x;
   double t2, fu, fv, fw, fx, xm, eps, tol1, tol3;
 
@@ -19,7 +19,7 @@ double Brent(Function f, double a, double b, double tol, Args... args) {
 
   d = 0.0;
   e = 0.0;
-  fx = f(x, args...);
+  fx = f(x, std::forward<Args>(args)...);
   fv = fx;
   fw = fx;
   tol3 = tol / 3.0;
@@ -77,7 +77,7 @@ double Brent(Function f, double a, double b, double tol, Args... args) {
       u = x - tol1;
     }
 
-    fu = f(u, args...);
+    fu = f(u, std::forward<Args>(args)...);
 
     if (fu <= fx) {
       if (u < x) {

--- a/include/grouped_array.h
+++ b/include/grouped_array.h
@@ -115,7 +115,8 @@ public:
   }
 
   template <typename Func>
-  void VariableTransform(Func f, const int *params, T *out) const noexcept {
+  void VariableTransform(Func f, const indptr_t *params,
+                         T *out) const noexcept {
 #pragma omp parallel for schedule(static) num_threads(num_threads_)
     for (int i = 0; i < n_groups_; ++i) {
       indptr_t start = indptr_[i];

--- a/include/scalers.h
+++ b/include/scalers.h
@@ -10,6 +10,11 @@ DLL_EXPORT double Float64_BoxCoxLambdaGuerrero(const double *x, int n,
                                                int period, double lower,
                                                double upper);
 
+DLL_EXPORT float Float32_BoxCoxLambdaLogLik(const float *x, int n, float lower,
+                                            float upper);
+DLL_EXPORT double Float64_BoxCoxLambdaLogLik(const double *x, int n,
+                                             double lower, double upper);
+
 DLL_EXPORT void Float32_BoxCoxTransform(const float *x, int n, float lambda,
                                         float *out);
 DLL_EXPORT void Float64_BoxCoxTransform(const double *x, int n, double lambda,
@@ -64,6 +69,13 @@ DLL_EXPORT int
 GroupedArrayFloat64_BoxCoxLambdaGuerrero(GroupedArrayHandle handle, int period,
                                          double lower, double upper,
                                          double *out);
+
+DLL_EXPORT void
+GroupedArrayFloat32_BoxCoxLambdaLogLik(GroupedArrayHandle handle, float lower,
+                                       float upper, float *out);
+DLL_EXPORT void
+GroupedArrayFloat64_BoxCoxLambdaLogLik(GroupedArrayHandle handle, double lower,
+                                       double upper, double *out);
 
 DLL_EXPORT int GroupedArrayFloat32_BoxCoxTransform(GroupedArrayHandle handle,
                                                    const float *lambdas,

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -129,13 +129,13 @@ def test_boxcox_correctness(data, indptr, dtype, method):
     if method == "loglik":
         data = np.abs(data)
     ga = GroupedArray(data, indptr)
-    sc = LocalBoxCoxScaler(season_length=10, method=method)
+    sc = LocalBoxCoxScaler(method=method, season_length=10)
     sc.fit(ga)
     transformed = sc.transform(ga)
     restored = sc.inverse_transform(GroupedArray(transformed, ga.indptr))
     atol = 5e-4 if dtype == np.float32 else 1e-8
     np.testing.assert_allclose(ga.data, restored, atol=atol)
-    lmbda = boxcox_lambda(ga[0], season_length=10, method=method)
+    lmbda = boxcox_lambda(ga[0], method=method, season_length=10)
     np.testing.assert_allclose(lmbda, sc.stats_[0, 0])
     first_grp = slice(indptr[0], indptr[1])
     first_tfm = boxcox(ga[0], lmbda)

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -120,19 +120,22 @@ def test_correctness(data, indptr, scaler_name, dtype):
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_boxcox_correctness(data, indptr, dtype):
+@pytest.mark.parametrize("method", ["guerrero", "loglik"])
+def test_boxcox_correctness(data, indptr, dtype, method):
     data = data.astype(dtype, copy=True)
     # introduce some nans
     for i in [1, 90, 177]:
         data[indptr[i] : indptr[i] + 19] = np.nan
+    if method == "loglik":
+        data = np.abs(data)
     ga = GroupedArray(data, indptr)
-    sc = LocalBoxCoxScaler(season_length=10)
+    sc = LocalBoxCoxScaler(season_length=10, method=method)
     sc.fit(ga)
     transformed = sc.transform(ga)
     restored = sc.inverse_transform(GroupedArray(transformed, ga.indptr))
     atol = 5e-4 if dtype == np.float32 else 1e-8
     np.testing.assert_allclose(ga.data, restored, atol=atol)
-    lmbda = boxcox_lambda(ga[0], 10)
+    lmbda = boxcox_lambda(ga[0], season_length=10, method=method)
     np.testing.assert_allclose(lmbda, sc.stats_[0, 0])
     first_grp = slice(indptr[0], indptr[1])
     first_tfm = boxcox(ga[0], lmbda)


### PR DESCRIPTION
Adds support for `method='loglik'` in the boxcox scalers which finds the lambda that minimizes the log-likelihood function.