### PR TITLE
use standard thread instead of openmp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
             platform-id: manylinux_aarch64
           - os: windows-2019
             platform-id: win_amd64
-          - os: macos-11
+          - os: macos-13
             platform-id: macosx_x86_64
           - os: macos-14
             platform-id: macosx_arm64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,35 +2,12 @@ cmake_minimum_required(VERSION 3.25)
 project(coreforecast)
 
 include(FetchContent)
-option(USE_OPENMP "Enable OpenMP" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
-
-if(USE_OPENMP)
-    if(APPLE)
-        find_package(OpenMP)
-
-        if(NOT OpenMP_FOUND)
-            # libomp 15.0+ from brew is keg-only, so have to search in other locations.
-            # See https://github.com/Homebrew/homebrew-core/issues/112107#issuecomment-1278042927.
-            execute_process(COMMAND brew --prefix libomp
-                OUTPUT_VARIABLE HOMEBREW_LIBOMP_PREFIX
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-            set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include")
-            set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include")
-            set(OpenMP_C_LIB_NAMES omp)
-            set(OpenMP_CXX_LIB_NAMES omp)
-            set(OpenMP_omp_LIBRARY ${HOMEBREW_LIBOMP_PREFIX}/lib/libomp.dylib)
-        endif()
-    endif()
-
-    find_package(OpenMP REQUIRED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
 
 if(APPLE)
     set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
@@ -81,8 +58,4 @@ add_library(coreforecast SHARED ${SOURCES})
 
 if(MSVC)
     set_target_properties(coreforecast PROPERTIES OUTPUT_NAME "libcoreforecast")
-endif()
-
-if(USE_OPENMP AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    target_link_libraries(coreforecast PUBLIC OpenMP::OpenMP_CXX)
 endif()

--- a/include/grouped_array.h
+++ b/include/grouped_array.h
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <thread>
+#include <vector>
 
 using indptr_t = int32_t;
 
@@ -43,122 +45,141 @@ public:
                int num_threads)
       : data_(data), indptr_(indptr), n_groups_(n_indptr - 1),
         num_threads_(num_threads) {}
-  ~GroupedArray() {}
+
+  template <typename Func> void Parallelize(Func f) const noexcept {
+    std::vector<std::thread> threads;
+    int groups_per_thread = n_groups_ / num_threads_;
+    int remainder = n_groups_ % num_threads_;
+    for (int t = 0; t < num_threads_; ++t) {
+      int start_group = t * groups_per_thread + std::min(t, remainder);
+      int end_group = (t + 1) * groups_per_thread + std::min(t + 1, remainder);
+      threads.emplace_back([=]() { f(start_group, end_group); });
+    }
+    for (auto &thread : threads) {
+      thread.join();
+    }
+  }
+
   template <typename Func, typename... Args>
   void Reduce(Func f, int n_out, T *out, int lag,
               Args &&...args) const noexcept {
-#pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int i = 0; i < n_groups_; ++i) {
-      indptr_t start = indptr_[i];
-      indptr_t end = indptr_[i + 1];
-      indptr_t n = end - start;
-      indptr_t start_idx = FirstNotNaN(data_ + start, n);
-      if (start_idx + lag >= n)
-        continue;
-      start += start_idx;
-      f(data_ + start, n - start_idx - lag, out + n_out * i,
-        std::forward<Args>(args)...);
-    }
+    Parallelize([&](int start_group, int end_group) {
+      for (int i = start_group; i < end_group; ++i) {
+        indptr_t start = indptr_[i];
+        indptr_t end = indptr_[i + 1];
+        indptr_t n = end - start;
+        indptr_t start_idx = FirstNotNaN(data_ + start, n);
+        if (start_idx + lag >= n)
+          return;
+        start += start_idx;
+        f(data_ + start, n - start_idx - lag, out + n_out * i, args...);
+      }
+    });
   }
 
   template <typename Func, typename... Args>
   void VariableReduce(Func f, const indptr_t *indptr_out, T *out,
                       Args &&...args) const noexcept {
-#pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int i = 0; i < n_groups_; ++i) {
-      indptr_t start = indptr_[i];
-      indptr_t end = indptr_[i + 1];
-      indptr_t n = end - start;
-      indptr_t out_n = indptr_out[i + 1] - indptr_out[i];
-      f(data_ + start, n, out + indptr_out[i], out_n,
-        std::forward<Args>(args)...);
-    }
+    Parallelize([&](int start_group, int end_group) {
+      for (int i = start_group; i < end_group; ++i) {
+        indptr_t start = indptr_[i];
+        indptr_t end = indptr_[i + 1];
+        indptr_t n = end - start;
+        indptr_t out_n = indptr_out[i + 1] - indptr_out[i];
+        f(data_ + start, n, out + indptr_out[i], out_n,
+          std::forward<Args>(args)...);
+      }
+    });
   }
 
   template <typename Func>
   void ScalerTransform(Func f, const T *stats, T *out) const noexcept {
-#pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int i = 0; i < n_groups_; ++i) {
-      indptr_t start = indptr_[i];
-      indptr_t end = indptr_[i + 1];
-      T offset = stats[2 * i];
-      T scale = stats[2 * i + 1];
-      if (std::abs(scale) < std::numeric_limits<T>::epsilon()) {
-        scale = static_cast<T>(1.0);
+    Parallelize([&](int start_group, int end_group) {
+      for (int i = start_group; i < end_group; ++i) {
+        indptr_t start = indptr_[i];
+        indptr_t end = indptr_[i + 1];
+        T offset = stats[2 * i];
+        T scale = stats[2 * i + 1];
+        if (std::abs(scale) < std::numeric_limits<T>::epsilon()) {
+          scale = static_cast<T>(1.0);
+        }
+        for (indptr_t j = start; j < end; ++j) {
+          out[j] = f(data_[j], offset, scale);
+        }
       }
-      for (indptr_t j = start; j < end; ++j) {
-        out[j] = f(data_[j], offset, scale);
-      }
-    }
+    });
   }
 
   template <typename Func, typename... Args>
   void Transform(Func f, int lag, T *out, Args &&...args) const noexcept {
-#pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int i = 0; i < n_groups_; ++i) {
-      indptr_t start = indptr_[i];
-      indptr_t end = indptr_[i + 1];
-      indptr_t n = end - start;
-      indptr_t start_idx = FirstNotNaN(data_ + start, n, out + start);
-      SkipLags(out + start + start_idx, n - start_idx, lag);
-      if (start_idx + lag >= n) {
-        continue;
+    Parallelize([&](int start_group, int end_group) {
+      for (int i = start_group; i < end_group; ++i) {
+        indptr_t start = indptr_[i];
+        indptr_t end = indptr_[i + 1];
+        indptr_t n = end - start;
+        indptr_t start_idx = FirstNotNaN(data_ + start, n, out + start);
+        SkipLags(out + start + start_idx, n - start_idx, lag);
+        if (start_idx + lag >= n) {
+          continue;
+        }
+        start += start_idx;
+        f(data_ + start, n - start_idx - lag, out + start + lag,
+          std::forward<Args>(args)...);
       }
-      start += start_idx;
-      f(data_ + start, n - start_idx - lag, out + start + lag,
-        std::forward<Args>(args)...);
-    }
+    });
   }
 
   template <typename Func>
   void VariableTransform(Func f, const indptr_t *params,
                          T *out) const noexcept {
-#pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int i = 0; i < n_groups_; ++i) {
-      indptr_t start = indptr_[i];
-      indptr_t end = indptr_[i + 1];
-      indptr_t n = end - start;
-      indptr_t start_idx = FirstNotNaN(data_ + start, n, out + start);
-      if (start_idx >= n) {
-        continue;
+    Parallelize([&](int start_group, int end_group) {
+      for (int i = start_group; i < end_group; ++i) {
+        indptr_t start = indptr_[i];
+        indptr_t end = indptr_[i + 1];
+        indptr_t n = end - start;
+        indptr_t start_idx = FirstNotNaN(data_ + start, n, out + start);
+        if (start_idx >= n) {
+          continue;
+        }
+        start += start_idx;
+        f(data_ + start, n - start_idx, params[i], out + start);
       }
-      start += start_idx;
-      f(data_ + start, n - start_idx, params[i], out + start);
-    }
+    });
   }
 
   template <typename Func, typename... Args>
   void TransformAndReduce(Func f, int lag, T *out, int n_agg, T *agg,
                           Args &&...args) const noexcept {
-#pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int i = 0; i < n_groups_; ++i) {
-      indptr_t start = indptr_[i];
-      indptr_t end = indptr_[i + 1];
-      indptr_t n = end - start;
-      indptr_t start_idx = FirstNotNaN(data_ + start, n, out + start);
-      SkipLags(out + start + start_idx, n - start_idx, lag);
-      if (start_idx + lag >= n) {
-        continue;
+    Parallelize([&](int start_group, int end_group) {
+      for (int i = start_group; i < end_group; ++i) {
+        indptr_t start = indptr_[i];
+        indptr_t end = indptr_[i + 1];
+        indptr_t n = end - start;
+        indptr_t start_idx = FirstNotNaN(data_ + start, n, out + start);
+        SkipLags(out + start + start_idx, n - start_idx, lag);
+        if (start_idx + lag >= n)
+          continue;
+        start += start_idx;
+        f(data_ + start, n - start_idx - lag, out + start + lag,
+          agg + i * n_agg, std::forward<Args>(args)...);
       }
-      start += start_idx;
-      f(data_ + start, n - start_idx - lag, out + start + lag, agg + i * n_agg,
-        std::forward<Args>(args)...);
-    }
+    });
   }
 
   template <typename Func>
   void Zip(Func f, const GroupedArray<T> &other, const indptr_t *out_indptr,
            T *out) const noexcept {
-#pragma omp parallel for schedule(static) num_threads(num_threads_)
-    for (int i = 0; i < n_groups_; ++i) {
-      indptr_t start = indptr_[i];
-      indptr_t end = indptr_[i + 1];
-      indptr_t n = end - start;
-      indptr_t other_start = other.indptr_[i];
-      indptr_t other_end = other.indptr_[i + 1];
-      indptr_t other_n = other_end - other_start;
-      f(data_ + start, n, other.data_ + other_start, other_n,
-        out + out_indptr[i]);
-    }
+    Parallelize([&](int start_group, int end_group) {
+      for (int i = start_group; i < end_group; ++i) {
+        indptr_t start = indptr_[i];
+        indptr_t end = indptr_[i + 1];
+        indptr_t n = end - start;
+        indptr_t other_start = other.indptr_[i];
+        indptr_t other_end = other.indptr_[i + 1];
+        indptr_t other_n = other_end - other_start;
+        f(data_ + start, n, other.data_ + other_start, other_n,
+          out + out_indptr[i]);
+      }
+    });
   }
 };

--- a/include/grouped_array.h
+++ b/include/grouped_array.h
@@ -53,7 +53,7 @@ public:
     for (int t = 0; t < num_threads_; ++t) {
       int start_group = t * groups_per_thread + std::min(t, remainder);
       int end_group = (t + 1) * groups_per_thread + std::min(t + 1, remainder);
-      threads.emplace_back([=]() { f(start_group, end_group); });
+      threads.emplace_back(f, start_group, end_group);
     }
     for (auto &thread : threads) {
       thread.join();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,4 @@ wheel.py-api = "py3"
 [tool.cibuildwheel]
 archs = "all"
 build-verbosity = 3
-macos.before-build = ["brew install libomp", "./scripts/switch_xcode"]
 test-command = 'python -c "import coreforecast._lib"'

--- a/scripts/switch_xcode
+++ b/scripts/switch_xcode
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-version=$(sw_vers -productVersion)
-major_version=${version%%.*}
-if [ "$major_version" -eq "11" ]; then
-    sudo xcode-select -s /Applications/Xcode_11.7.app/Contents/Developer
-fi


### PR DESCRIPTION
Switches from using OpenMP to using `std::thread` to ease the build process and also get rid of the problems caused in MacOS when installing in a conda environment using pip.