### PR TITLE
fix: remove _greatest_autocovariance

### DIFF
--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -576,13 +576,6 @@ public:
         out.mutable_data());
     return out;
   }
-
-  py::array_t<T> GreatestAutocovariance(int max_lag) {
-    py::array_t<T> out(NumGroups());
-    Reduce(seasonal::GreatestAutocovariance<T>, 1, out.mutable_data(), 0,
-           max_lag);
-    return out;
-  }
 };
 
 template <typename T> void bind_ga(py::module &m, const std::string &name) {
@@ -658,9 +651,7 @@ template <typename T> void bind_ga(py::module &m, const std::string &name) {
       .def("_diff", &GroupedArray<T>::Difference)
       .def("_diffs", &GroupedArray<T>::Differences)
       .def("_inv_diff", &GroupedArray<T>::InvertDifference)
-      .def("_inv_diffs", &GroupedArray<T>::InvertDifferences)
-      .def("_greatest_autocovariance",
-           &GroupedArray<T>::GreatestAutocovariance);
+      .def("_inv_diffs", &GroupedArray<T>::InvertDifferences);
 }
 
 void init_ga(py::module_ &m) {

--- a/tests/test_ga_fns.py
+++ b/tests/test_ga_fns.py
@@ -5,11 +5,11 @@ from coreforecast.grouped_array import GroupedArray
 
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
 @pytest.mark.parametrize("season_length", [7, 12, 24])
-def test_greatest_autocovariance(dtype, season_length):
+def test_periods(dtype, season_length):
     sizes = np.random.randint(2 * season_length, 100, 500)
     data = np.hstack([np.arange(size, dtype=dtype) % season_length for size in sizes])
     ga = GroupedArray(data, np.append(0, sizes.cumsum()))
-    lengths = ga._greatest_autocovariance(50)
+    lengths = ga._periods(50)
     unique_lengths = np.unique(lengths)
     assert unique_lengths.size == 1
     assert unique_lengths.item() == season_length


### PR DESCRIPTION
This functionality was already available in the `_periods` method.