### PR TITLE
ci: use arm runners for aarch64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         os-platform:
           [
             [ubuntu-latest, manylinux_x86_64],
-            [ubuntu-latest, manylinux_aarch64],
+            [ubuntu-24.04-arm, manylinux_aarch64],
             [windows-latest, win_amd64],
             [macos-13, macosx_x86_64],
             [macos-14, macosx_arm64],
@@ -34,12 +34,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: "true"
-
-      - name: Set up QEMU
-        if: matrix.os-platform[1] == 'manylinux_aarch64'
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-        with:
-          platforms: arm64
 
       - name: Set up uv
         uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ wheel.packages = ["python/coreforecast"]
 archs = "all"
 build-verbosity = 3
 test-extras = "dev"
-test-skip = "*linux_aarch64"
 
 [tool.pyright]
 venvPath = "."


### PR DESCRIPTION
Switches to the github hosted runners with arm64 for the aarch64 jobs to remove emulation.