### PR TITLE
fix: add non-contiguous array support for C++ EMA

### DIFF
--- a/include/coreforecast/exponentially_weighted.h
+++ b/include/coreforecast/exponentially_weighted.h
@@ -2,10 +2,10 @@
 
 namespace exponentially_weighted {
 template <typename T>
-inline void MeanTransform(const T *data, int n, T *out, T alpha) {
+inline void MeanTransform(const T *data, int n, T *out, T alpha, ptrdiff_t stride) {
   out[0] = data[0];
   for (int i = 1; i < n; ++i) {
-    out[i] = alpha * data[i] + (1 - alpha) * out[i - 1];
+    out[i] = alpha * data[i * stride / sizeof(T)] + (1 - alpha) * out[i - 1];
   }
 }
 } // namespace exponentially_weighted

--- a/include/coreforecast/exponentially_weighted.h
+++ b/include/coreforecast/exponentially_weighted.h
@@ -2,10 +2,10 @@
 
 namespace exponentially_weighted {
 template <typename T>
-inline void MeanTransform(const T *data, int n, T *out, T alpha, ptrdiff_t stride) {
+inline void MeanTransform(const T *data, int n, T *out, T alpha) {
   out[0] = data[0];
   for (int i = 1; i < n; ++i) {
-    out[i] = alpha * data[i * stride / sizeof(T)] + (1 - alpha) * out[i - 1];
+    out[i] = alpha * data[i] + (1 - alpha) * out[i - 1];
   }
 }
 } // namespace exponentially_weighted

--- a/src/exponentially_weighted.cpp
+++ b/src/exponentially_weighted.cpp
@@ -6,7 +6,8 @@ template <typename T>
 py::array_t<T> ExponentiallyWeightedMean(const py::array_t<T> data, T alpha) {
   py::array_t<T> out(data.size());
   exponentially_weighted::MeanTransform<T>(data.data(), data.size(),
-                                           out.mutable_data(), alpha);
+                                           out.mutable_data(), alpha, 
+                                           data.strides()[0]);
   return out;
 }
 

--- a/src/exponentially_weighted.cpp
+++ b/src/exponentially_weighted.cpp
@@ -3,7 +3,9 @@
 #include "exponentially_weighted.h"
 
 template <typename T>
-py::array_t<T> ExponentiallyWeightedMean(const py::array_t<T, py::array::c_style | py::array::forcecast> data, T alpha) {
+py::array_t<T> ExponentiallyWeightedMean(
+    const py::array_t<T, py::array::c_style | py::array::forcecast> data,
+    T alpha) {
   py::array_t<T> out(data.size());
   exponentially_weighted::MeanTransform<T>(data.data(), data.size(),
                                            out.mutable_data(), alpha);

--- a/src/exponentially_weighted.cpp
+++ b/src/exponentially_weighted.cpp
@@ -3,11 +3,10 @@
 #include "exponentially_weighted.h"
 
 template <typename T>
-py::array_t<T> ExponentiallyWeightedMean(const py::array_t<T> data, T alpha) {
+py::array_t<T> ExponentiallyWeightedMean(const py::array_t<T, py::array::c_style | py::array::forcecast> data, T alpha) {
   py::array_t<T> out(data.size());
   exponentially_weighted::MeanTransform<T>(data.data(), data.size(),
-                                           out.mutable_data(), alpha, 
-                                           data.strides()[0]);
+                                           out.mutable_data(), alpha);
   return out;
 }
 


### PR DESCRIPTION
**Summary**

My PR, nixtla/statsforecast#973, is failing some tests as `exponentially_weighted_mean` requires `x` to be contiguous, which causes issues when slicing with a step like in `SeasonalExponentialSmoothing`.

In order to avoid the need for an explicit copy, I made some small changes to `exponentially_weighted.h` and `exponentially_weighted.cpp` to support traversing non-contiguous arrays.

```cpp
template <typename T>
inline void MeanTransform(const T *data, int n, T *out, T alpha, uintptr_t stride) {
  out[0] = data[0];
  for (int i = 1; i < n; ++i) {
    out[i] = alpha * data[i * stride / sizeof(T)] + (1 - alpha) * out[i - 1];
  }
}
```

```cpp
template <typename T>
py::array_t<T> ExponentiallyWeightedMean(const py::array_t<T> data, T alpha) {
  py::array_t<T> out(data.size());
  exponentially_weighted::MeanTransform<T>(data.data(), data.size(),
                                           out.mutable_data(), alpha, 
                                           data.strides()[0]);
  return out;
}
```

**Example**

<img width="460" alt="image" src="https://github.com/user-attachments/assets/ea8996dd-3532-47b4-a425-88df70623a34" />