### PR TITLE
fix: Box-Cox lambda when using Guerrero's method

### DIFF
--- a/include/coreforecast/scalers.h
+++ b/include/coreforecast/scalers.h
@@ -79,8 +79,8 @@ T BoxCox_GuerreroCV(T lambda, const std::vector<T> &x_mean,
   auto x_rat =
       std_vec.array() / (mean_vec.array().log() * (1.0 - lambda)).exp();
   double mean = x_rat.mean();
-  double std = (x_rat.array() - mean).square().sum() / (x_rat.size() - 1);
-  return static_cast<T>(std / mean);
+  double var = (x_rat.array() - mean).square().sum() / (x_rat.size() - 1);
+  return static_cast<T>(std::sqrt(var) / mean);
 }
 
 template <typename T>

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -92,7 +92,7 @@ def test_boxcox_correctness(data, indptr, dtype, method):
     np.testing.assert_allclose(first_restored, restored[first_grp])
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_guerrero_correctness():
+def test_guerrero_correctness(dtype):
     data = [194, 229, 249, 203, 196, 238, 252, 210, 205, 236]
     expected_lambda = 1.99 # value from R's BoxCox.lambda function (forecast package)
     calculated_lambda = boxcox_lambda(data, method="guerrero", season_length=4)

--- a/tests/test_scalers.py
+++ b/tests/test_scalers.py
@@ -91,6 +91,12 @@ def test_boxcox_correctness(data, indptr, dtype, method):
     np.testing.assert_allclose(first_tfm, transformed[first_grp])
     np.testing.assert_allclose(first_restored, restored[first_grp])
 
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_guerrero_correctness():
+    data = [194, 229, 249, 203, 196, 238, 252, 210, 205, 236]
+    expected_lambda = 1.99 # value from R's BoxCox.lambda function (forecast package)
+    calculated_lambda = boxcox_lambda(data, method="guerrero", season_length=4)
+    np.testing.assert_allclose(calculated_lambda, expected_lambda, atol=0.1)
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_difference_correctness(data, indptr, dtype):


### PR DESCRIPTION
**Description**
This PR changes how the lambda of the Box–Cox transformation using Guerrero’s method is calculated. Previously, the `scalers.boxcox_lambda` function was returning the variance / mean rather than the intended standard deviation / mean.

**Validation**
I added a test that compares the output of `scalers.boxcox_lambda` to the output of R’s `forecast::BoxCox_lambda()`. The data used corresponds to the `aus_production` dataset from the `tsibbledata` R package, specifically, the last 10 values of quarterly gas production. 
