### PR TITLE
fix: handle None __doc__ when PYTHONOPTIMIZE=2

### DIFF
--- a/python/coreforecast/expanding.py
+++ b/python/coreforecast/expanding.py
@@ -43,7 +43,8 @@ def _expanding_docstring(*args, **kwargs) -> Callable:
 
     def docstring_decorator(function: Callable):
         fname = function.__name__
-        function.__doc__ = base_docstring.format(fname, fname, fname)
+        if function.__doc__:
+            function.__doc__ = base_docstring.format(fname, fname, fname)
         return function
 
     return docstring_decorator(*args, **kwargs)

--- a/python/coreforecast/rolling.py
+++ b/python/coreforecast/rolling.py
@@ -63,7 +63,8 @@ def _rolling_docstring(*args, **kwargs) -> Callable:
     """
 
     def docstring_decorator(function: Callable):
-        function.__doc__ = base_docstring.format(function.__name__)
+        if function.__doc__:
+            function.__doc__ = base_docstring.format(function.__name__)
         return function
 
     return docstring_decorator(*args, **kwargs)
@@ -88,7 +89,8 @@ def _seasonal_rolling_docstring(*args, **kwargs) -> Callable:
     """
 
     def docstring_decorator(function: Callable):
-        function.__doc__ = base_docstring.format(function.__name__)
+        if function.__doc__:
+            function.__doc__ = base_docstring.format(function.__name__)
         return function
 
     return docstring_decorator(*args, **kwargs)


### PR DESCRIPTION
Fixes Nixtla/statsforecast#976

### Description

When Python runs with `PYTHONOPTIMIZE=2` (or `-OO`), `__doc__` attributes are stripped and set to `None`. The `_expanding_docstring`, `_rolling_docstring`, and `_seasonal_rolling_docstring` decorators set `function.__doc__ = base_docstring.format(...)`, which fails with `AttributeError: 'NoneType' object has no attribute 'format'` when `__doc__` is `None`.

### Changes

- Added `if function.__doc__:` guards before formatting docstrings in `expanding.py` and `rolling.py`
- Ensures compatibility with PYTHONOPTIMIZE=2 while preserving existing docstring behavior when docs are not stripped

### Related

- https://github.com/Nixtla/statsforecast/issues/976

### AI Declaration

AI tools assisted with code generation and PR description. The bug was manually reproduced and confirmed in `coreforecast` (the underlying dependency of `statsforecast`). All changes are human-approved and tested.