### PR TITLE
fix: NaN contract, kernel argument validation, and float64 input widening

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -103,19 +103,24 @@ jobs:
         run: uv sync --group dev --no-install-project
 
       # not editable: the scikit-build redirecting finder would otherwise import
-      # whatever _lib the sync left behind instead of the instrumented one
+      # whatever _lib the sync left behind instead of the instrumented one.
+      # No linker flags: cmake puts CMAKE_CXX_FLAGS on the link line too, so the
+      # module already comes out with libasan and libubsan as DT_NEEDED. The
+      # SHARED ones wouldn't apply either, pybind11_add_module builds a MODULE
       - name: Build with the sanitizers
         run: |
           uv pip install . \
             -Ccmake.build-type=Debug \
-            -Ccmake.define.CMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -D_GLIBCXX_ASSERTIONS" \
-            -Ccmake.define.CMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"
+            -Ccmake.define.CMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -D_GLIBCXX_ASSERTIONS"
 
       # --no-sync so it can't reinstall the project over the instrumented build.
-      # Both runtimes get preloaded: the module is built with address,undefined,
-      # and with libasan alone the process dies with no report the first time a
-      # kernel throws. detect_leaks=0 because CPython leaks by design;
-      # halt_on_error makes a UBSan report fail the job instead of only printing
+      # The runtimes still have to be preloaded even though the module links
+      # them: python isn't instrumented, so pulling them in with the module
+      # leaves ASan initializing too late to be usable ("runtime does not come
+      # first in initial library list"). Both of them, since with libasan alone
+      # the process dies with no report the first time a kernel throws.
+      # detect_leaks=0 because CPython leaks by design; halt_on_error makes a
+      # UBSan report fail the job instead of only printing
       - name: Run tests
         env:
           ASAN_OPTIONS: detect_leaks=0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,6 +43,79 @@ jobs:
           CIBW_BEFORE_TEST: uv sync --group dev --active
           CIBW_TEST_COMMAND: uv run pytest {project}/tests -k "not efficiency"
 
+  warnings:
+    name: Build with -Werror on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          submodules: "true"
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      # gcc here, AppleClang on macOS; -Werror is off by default so that a new
+      # compiler warning fails this job instead of everyone's source install
+      - name: Build with warnings as errors
+        run: uv build --wheel -Ccmake.define.COREFORECAST_WERROR=ON
+
+  sanitizers:
+    name: Run tests under ASan and UBSan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          submodules: "true"
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      # not editable: the scikit-build redirecting finder would otherwise import
+      # whatever _lib the sync left behind instead of the instrumented one
+      - name: Build with the sanitizers
+        run: |
+          uv pip install . \
+            -Ccmake.build-type=Debug \
+            -Ccmake.define.CMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -D_GLIBCXX_ASSERTIONS" \
+            -Ccmake.define.CMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"
+
+      # detect_leaks=0 because CPython leaks by design; halt_on_error makes a
+      # UBSan report fail the job instead of only printing
+      - name: Run tests
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: |
+          LD_PRELOAD=$(gcc -print-file-name=libasan.so) \
+            uv run pytest tests -k "not efficiency"
+
   run_benchmarks:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -97,8 +97,10 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
+      # --no-install-project so uv never builds an uninstrumented coreforecast:
+      # it caches that wheel and restores it over the sanitizer build below
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --no-install-project
 
       # not editable: the scikit-build redirecting finder would otherwise import
       # whatever _lib the sync left behind instead of the instrumented one
@@ -109,15 +111,17 @@ jobs:
             -Ccmake.define.CMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -D_GLIBCXX_ASSERTIONS" \
             -Ccmake.define.CMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"
 
-      # detect_leaks=0 because CPython leaks by design; halt_on_error makes a
-      # UBSan report fail the job instead of only printing
+      # --no-sync for the same reason: a re-sync here reinstalls the project, and
+      # throwing from an uninstrumented library under a preloaded libasan kills
+      # the process with no report. detect_leaks=0 because CPython leaks by
+      # design; halt_on_error makes a UBSan report fail the job, not only print
       - name: Run tests
         env:
           ASAN_OPTIONS: detect_leaks=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
           LD_PRELOAD=$(gcc -print-file-name=libasan.so) \
-            uv run pytest tests -k "not efficiency"
+            uv run --no-sync pytest tests -k "not efficiency"
 
   run_benchmarks:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,8 @@
 name: pytest
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -111,16 +111,17 @@ jobs:
             -Ccmake.define.CMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -D_GLIBCXX_ASSERTIONS" \
             -Ccmake.define.CMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"
 
-      # --no-sync for the same reason: a re-sync here reinstalls the project, and
-      # throwing from an uninstrumented library under a preloaded libasan kills
-      # the process with no report. detect_leaks=0 because CPython leaks by
-      # design; halt_on_error makes a UBSan report fail the job, not only print
+      # --no-sync so it can't reinstall the project over the instrumented build.
+      # Both runtimes get preloaded: the module is built with address,undefined,
+      # and with libasan alone the process dies with no report the first time a
+      # kernel throws. detect_leaks=0 because CPython leaks by design;
+      # halt_on_error makes a UBSan report fail the job instead of only printing
       - name: Run tests
         env:
           ASAN_OPTIONS: detect_leaks=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
-          LD_PRELOAD=$(gcc -print-file-name=libasan.so) \
+          LD_PRELOAD="$(gcc -print-file-name=libasan.so):$(gcc -print-file-name=libubsan.so)" \
             uv run --no-sync pytest tests -k "not efficiency"
 
   run_benchmarks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## Unreleased
+
+### Breaking changes
+
+- The free functions in `coreforecast.rolling`, `coreforecast.expanding` and
+  `coreforecast.exponentially_weighted` now preserve a leading run of NaNs and
+  compute the statistic over what follows it. They used to return all NaN as
+  soon as the series started with one. With `skipna=True`, `min_samples` counts
+  positions after that run, which is what pandas does.
+- Input without a float dtype (integer arrays, lists, Series) is now widened to
+  float64 instead of float32. Values from `2**24` on were silently rounded
+  before; the result now takes twice the memory. Pass a float32 array to get
+  float32 back, which was already the only way to be sure of it.
+- Arguments that used to read or write out of bounds are rejected with a
+  `ValueError` or an `IndexError` instead: non-positive `window_size`,
+  `min_samples` and `season_length`, negative `lag`, `d` and `k`, quantile
+  levels outside `[0, 1]`, `indptr` entries that are negative, decreasing or
+  too large for an int32, out-of-range group indices, and `ds`, `stats`,
+  `periods` and `tails` arrays whose size doesn't match the group count.
+  Calling `update` on a lag transform built with `lag=0` also raises now: an
+  update reads the value that isn't in the array yet, so there is nothing for
+  it to consume.
+
+### Documentation
+
+- The local scalers' `skipna` documentation said an interior NaN "may result in
+  NaN statistics". It doesn't for min-max, where the result is whichever value
+  wins an unordered comparison. With `skipna=False` only a leading run of NaNs
+  is supported; pass `skipna=True` for anything else.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
   `coreforecast.exponentially_weighted` now preserve a leading run of NaNs and
   compute the statistic over what follows it. They used to return all NaN as
   soon as the series started with one. With `skipna=True`, `min_samples` counts
-  positions after that run, which is what pandas does.
+  positions after that run, which is what pandas does. The seasonal variants
+  split what follows the run into seasons, so a leading run whose length isn't a
+  multiple of `season_length` now groups different positions together than it
+  used to.
 - Input without a float dtype (integer arrays, lists, Series) is now widened to
   float64 instead of float32. Values from `2**24` on were silently rounded
   before; the result now takes twice the memory. Pass a float32 array to get

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,29 @@ set(PYBIND11_NEWPYTHON ON)
 
 find_package(pybind11 CONFIG REQUIRED)
 
+include_directories(include/coreforecast)
+# SYSTEM keeps the third-party headers out of the warning gate below
 include_directories(
-  include/coreforecast
+  SYSTEM
   external_libs/skiplist/src/cpp
   external_libs/stl-cpp/include
   external_libs/eigen)
 file(GLOB SOURCES src/*.cpp external_libs/skiplist/src/cpp/SkipList.cpp)
 pybind11_add_module(_lib ${SOURCES})
+
+# MSVC is left out until /W4 on the Eigen and pybind11 headers gets its own pass
+target_compile_options(
+  _lib PRIVATE $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra>)
+# Off by default so a new compiler warning about existing code can't break a
+# source install; the warnings job in CI turns it on.
+option(COREFORECAST_WERROR "Treat compiler warnings as errors" OFF)
+if(COREFORECAST_WERROR)
+  target_compile_options(
+    _lib PRIVATE $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Werror>)
+endif()
+# vendored source, built into the same target, so its warnings aren't ours
+set_source_files_properties(
+  external_libs/skiplist/src/cpp/SkipList.cpp
+  PROPERTIES COMPILE_OPTIONS $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-w>)
 
 install(TARGETS _lib DESTINATION .)

--- a/include/coreforecast/common.h
+++ b/include/coreforecast/common.h
@@ -21,7 +21,8 @@ using CArray = py::array_t<T, py::array::c_style | py::array::forcecast>;
 // Ensures contiguity without putting c_style on the parameter itself: doing
 // that makes array_t::check_ fail for a strided array, so pybind's
 // no-conversion pass matches no overload and the conversion pass picks the
-// first one registered, silently downcasting float64 input to float32.
+// first one registered, silently converting the input to that overload's dtype
+// (float64, which is the one registered first).
 template <typename T>
 inline CArray<T> AsContiguous(const py::array_t<T> &data) {
   return CArray<T>::ensure(data);

--- a/include/coreforecast/common.h
+++ b/include/coreforecast/common.h
@@ -10,6 +10,21 @@
 using indptr_t = int32_t;
 namespace py = pybind11;
 
+// Contiguous input array. The kernels take a raw pointer, so a strided view
+// would be read as if it were contiguous and silently give results for the
+// wrong elements.
+template <typename T>
+using CArray = py::array_t<T, py::array::c_style | py::array::forcecast>;
+
+// Ensures contiguity without putting c_style on the parameter itself: doing
+// that makes array_t::check_ fail for a strided array, so pybind's
+// no-conversion pass matches no overload and the conversion pass picks the
+// first one registered, silently downcasting float64 input to float32.
+template <typename T>
+inline CArray<T> AsContiguous(const py::array_t<T> &data) {
+  return CArray<T>::ensure(data);
+}
+
 template <typename T> inline indptr_t FirstNotNaN(const T *data, indptr_t n) {
   indptr_t i = 0;
   while (i < n && std::isnan(data[i])) {
@@ -31,7 +46,8 @@ inline indptr_t FirstNotNaN(const T *data, indptr_t n, T *out) {
 // to the output and only the valid tail is handed to `f`, which is what
 // GroupedArray::Transform already does for the grouped entry points.
 template <typename T, typename Func>
-inline py::array_t<T> SkipLeadingNaN(const py::array_t<T> data, Func f) {
+inline py::array_t<T> SkipLeadingNaN(const py::array_t<T> &data_arg, Func f) {
+  const auto data = AsContiguous(data_arg);
   py::array_t<T> out(data.size());
   auto n = static_cast<indptr_t>(data.size());
   indptr_t start = FirstNotNaN(data.data(), n, out.mutable_data());

--- a/include/coreforecast/common.h
+++ b/include/coreforecast/common.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cmath>
 #include <cstdint>
+#include <limits>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>

--- a/include/coreforecast/common.h
+++ b/include/coreforecast/common.h
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <stdexcept>
+#include <string>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
@@ -23,6 +25,22 @@ using CArray = py::array_t<T, py::array::c_style | py::array::forcecast>;
 template <typename T>
 inline CArray<T> AsContiguous(const py::array_t<T> &data) {
   return CArray<T>::ensure(data);
+}
+
+// Counts that index into the buffers: zero or less makes the growing loops in
+// the kernels start at -1 and read and write one element before them.
+inline void RequirePositive(const char *name, int value) {
+  if (value > 0) {
+    return;
+  }
+  throw std::invalid_argument(std::string(name) + " must be greater than 0");
+}
+
+// Offsets into the buffers: a negative one reads and writes before their start.
+inline void RequireNonNegative(const char *name, int value) {
+  if (value < 0) {
+    throw std::invalid_argument(std::string(name) + " must be non-negative");
+  }
 }
 
 template <typename T> inline indptr_t FirstNotNaN(const T *data, indptr_t n) {

--- a/include/coreforecast/common.h
+++ b/include/coreforecast/common.h
@@ -24,3 +24,17 @@ inline indptr_t FirstNotNaN(const T *data, indptr_t n, T *out) {
   }
   return i;
 }
+
+// The kernels assume NaNs only appear as a leading run, so the prefix is copied
+// to the output and only the valid tail is handed to `f`, which is what
+// GroupedArray::Transform already does for the grouped entry points.
+template <typename T, typename Func>
+inline py::array_t<T> SkipLeadingNaN(const py::array_t<T> data, Func f) {
+  py::array_t<T> out(data.size());
+  auto n = static_cast<indptr_t>(data.size());
+  indptr_t start = FirstNotNaN(data.data(), n, out.mutable_data());
+  if (start < n) {
+    f(data.data() + start, n - start, out.mutable_data() + start);
+  }
+  return out;
+}

--- a/include/coreforecast/diff.h
+++ b/include/coreforecast/diff.h
@@ -69,6 +69,12 @@ template <typename T> void NumDiffs(const T *x, indptr_t n, T *out, int max_d) {
 
 template <typename T>
 void NumSeasDiffs(const T *x, indptr_t n, T *out, int period, int max_d) {
+  RequireNonNegative("season_length", period);
+  // find_season_length passes the zero it gets when it finds no seasonality
+  if (period == 0) {
+    *out = 0;
+    return;
+  }
   // assume there are only NaNs at the start
   indptr_t start_idx = FirstNotNaN(x, n);
   x += start_idx;

--- a/include/coreforecast/expanding.h
+++ b/include/coreforecast/expanding.h
@@ -59,6 +59,7 @@ inline void QuantileTransform(const T *data, int n, T *out, T p,
 template <typename T>
 inline void QuantileUpdate(const T *data, int n, T *out, T p,
                            bool skipna = false) {
+  rolling::RequireProbability("p", p);
   if (!skipna) {
     std::vector<T> buffer(data, data + n);
     *out = stats::Quantile(buffer.begin(), buffer.end(), p);

--- a/include/coreforecast/rolling.h
+++ b/include/coreforecast/rolling.h
@@ -211,7 +211,8 @@ inline void StdTransform(const T *data, int n, T *out, int window_size,
 template <typename T, typename Comp, bool SkipNA> class CompAccumulator {
 public:
   CompAccumulator(int window_size) : window_size_(window_size) {
-    buffer_.reserve(window_size);
+    // resize, not reserve: the ring buffer is written through operator[]
+    buffer_.resize(window_size);
   }
   inline bool Empty() const noexcept { return tail_ == -1; }
   inline void PushBack(int i, T x) noexcept {
@@ -268,6 +269,11 @@ public:
 
     if constexpr (SkipNA) {
       if (std::isnan(x)) {
+        // the front can expire on this step even though nothing is inserted;
+        // skipping the check leaves an out-of-window entry to be returned
+        if (!Empty() && Front().first <= i_) {
+          PopFront();
+        }
         ++i_;
         return;
       }

--- a/include/coreforecast/rolling.h
+++ b/include/coreforecast/rolling.h
@@ -10,9 +10,8 @@
 
 namespace rolling {
 
-// Counts that index into the buffers. The bound signatures take these as
-// unsigned so a negative is rejected at the Python boundary; zero still has to
-// be rejected here, otherwise the growing loop below starts at -1.
+// Counts that index into the buffers: zero or less makes the growing loop
+// below start at -1 and read and write one element before them.
 inline void RequirePositive(const char *name, int value) {
   if (value > 0) {
     return;
@@ -546,6 +545,8 @@ void SeasonalQuantileTransform(const T *data, int n, T *out, int season_length,
 template <typename Func, typename T, typename... Args>
 inline void Update(Func RollingTfm, const T *data, int n, T *out,
                    int window_size, int min_samples, Args &&...args) {
+  // hoisted from the kernel: the buffer below is sized from window_size
+  RequirePositive("window_size", window_size);
   if (n < min_samples) {
     *out = std::numeric_limits<T>::quiet_NaN();
     return;
@@ -593,6 +594,7 @@ inline void SeasonalUpdate(Func RollingUpdate, const T *data, int n, T *out,
                            int season_length, int window_size, int min_samples,
                            Args &&...args) {
   RequirePositive("season_length", season_length);
+  RequirePositive("window_size", window_size);
   int season = n % season_length;
   int season_n = n / season_length + (season > 0);
   if (season_n < min_samples) {

--- a/include/coreforecast/rolling.h
+++ b/include/coreforecast/rolling.h
@@ -5,19 +5,11 @@
 #include <stdexcept>
 #include <string>
 
+#include "common.h"
 #include "stats.h"
 #include <variant>
 
 namespace rolling {
-
-// Counts that index into the buffers: zero or less makes the growing loop
-// below start at -1 and read and write one element before them.
-inline void RequirePositive(const char *name, int value) {
-  if (value > 0) {
-    return;
-  }
-  throw std::invalid_argument(std::string(name) + " must be greater than 0");
-}
 
 // Quantile levels index into the sorted window, so a value outside [0, 1]
 // indexes past its end. NaN fails both comparisons and is rejected too.
@@ -123,15 +115,6 @@ inline void StdTransformWithStats(const T *data, int n, T *out, T *agg,
                                   int min_samples, bool skipna = false) {
   RequirePositive("window_size", window_size);
   RequirePositive("min_samples", min_samples);
-  if (n < 1) {
-    std::fill(out, out + n, std::numeric_limits<T>::quiet_NaN());
-    if (save_stats) {
-      agg[0] = static_cast<T>(n);
-      agg[1] = std::numeric_limits<T>::quiet_NaN();
-      agg[2] = std::numeric_limits<T>::quiet_NaN();
-    }
-    return;
-  }
   if (!skipna) {
     // Fast path: original implementation without NaN checking
     T prev_avg = static_cast<T>(0.0);

--- a/include/coreforecast/rolling.h
+++ b/include/coreforecast/rolling.h
@@ -309,7 +309,7 @@ public:
 
   void Update(T x) noexcept { Insert(x); }
 
-  T Update(T x, int n) noexcept {
+  T Update(T x, int) noexcept {
     Insert(x);
     if constexpr (!SkipNA) {
       if (has_nan_)
@@ -320,7 +320,7 @@ public:
     return Front().second;
   }
 
-  T Update(T new_x, T old_x) noexcept {
+  T Update(T new_x, T) noexcept {
     Insert(new_x);
     if constexpr (!SkipNA) {
       if (has_nan_)

--- a/include/coreforecast/rolling.h
+++ b/include/coreforecast/rolling.h
@@ -2,10 +2,32 @@
 
 #include "SkipList.h"
 
+#include <stdexcept>
+#include <string>
+
 #include "stats.h"
 #include <variant>
 
 namespace rolling {
+
+// Counts that index into the buffers. The bound signatures take these as
+// unsigned so a negative is rejected at the Python boundary; zero still has to
+// be rejected here, otherwise the growing loop below starts at -1.
+inline void RequirePositive(const char *name, int value) {
+  if (value > 0) {
+    return;
+  }
+  throw std::invalid_argument(std::string(name) + " must be greater than 0");
+}
+
+// Quantile levels index into the sorted window, so a value outside [0, 1]
+// indexes past its end. NaN fails both comparisons and is rejected too.
+inline void RequireProbability(const char *name, double value) {
+  if (value >= 0.0 && value <= 1.0) {
+    return;
+  }
+  throw std::invalid_argument(std::string(name) + " must be between 0 and 1");
+}
 
 template <typename T, bool SkipNA> class MeanAccumulator {
 public:
@@ -63,6 +85,8 @@ private:
 template <typename T, typename Accumulator, typename... Args>
 inline void Transform(const T *data, int n, T *out, int window_size,
                       int min_samples, Args &&...args) {
+  RequirePositive("window_size", window_size);
+  RequirePositive("min_samples", min_samples);
   if (n < min_samples) {
     std::fill(out, out + n, std::numeric_limits<T>::quiet_NaN());
     return;
@@ -98,6 +122,17 @@ template <typename T>
 inline void StdTransformWithStats(const T *data, int n, T *out, T *agg,
                                   bool save_stats, int window_size,
                                   int min_samples, bool skipna = false) {
+  RequirePositive("window_size", window_size);
+  RequirePositive("min_samples", min_samples);
+  if (n < 1) {
+    std::fill(out, out + n, std::numeric_limits<T>::quiet_NaN());
+    if (save_stats) {
+      agg[0] = static_cast<T>(n);
+      agg[1] = std::numeric_limits<T>::quiet_NaN();
+      agg[2] = std::numeric_limits<T>::quiet_NaN();
+    }
+    return;
+  }
   if (!skipna) {
     // Fast path: original implementation without NaN checking
     T prev_avg = static_cast<T>(0.0);
@@ -437,6 +472,7 @@ private:
 template <typename T>
 inline void QuantileTransform(const T *data, int n, T *out, int window_size,
                               int min_samples, T p, bool skipna = false) {
+  RequireProbability("p", p);
   if (skipna) {
     Transform<T, QuantileAccumulator<T, true>>(data, n, out, window_size,
                                                min_samples, p);
@@ -450,6 +486,7 @@ template <typename Func, typename T, typename... Args>
 inline void SeasonalTransform(Func RollingTfm, const T *data, int n, T *out,
                               int season_length, int window_size,
                               int min_samples, Args &&...args) {
+  RequirePositive("season_length", season_length);
   int buff_size = n / season_length + (n % season_length > 0);
   std::vector<T> season_data(buff_size);
   std::vector<T> season_out(buff_size);
@@ -555,6 +592,7 @@ template <typename Func, typename T, typename... Args>
 inline void SeasonalUpdate(Func RollingUpdate, const T *data, int n, T *out,
                            int season_length, int window_size, int min_samples,
                            Args &&...args) {
+  RequirePositive("season_length", season_length);
   int season = n % season_length;
   int season_n = n / season_length + (season > 0);
   if (season_n < min_samples) {

--- a/include/coreforecast/rolling.h
+++ b/include/coreforecast/rolling.h
@@ -2,6 +2,7 @@
 
 #include "SkipList.h"
 
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -227,10 +228,16 @@ inline void StdTransform(const T *data, int n, T *out, int window_size,
 // ============================================================================
 template <typename T, typename Comp, bool SkipNA> class CompAccumulator {
 public:
-  CompAccumulator(int window_size) : window_size_(window_size) {
-    // resize, not reserve: the ring buffer is written through operator[]
-    buffer_.resize(window_size);
-  }
+  // std::pair's default constructor value-initializes, which would zero the
+  // whole ring buffer on every allocation; this aggregate's one is trivial
+  struct Entry {
+    int index;
+    T value;
+  };
+
+  CompAccumulator(int window_size)
+      : buffer_(std::make_unique_for_overwrite<Entry[]>(window_size)),
+        window_size_(window_size) {}
   inline bool Empty() const noexcept { return tail_ == -1; }
   inline void PushBack(int i, T x) noexcept {
     if (tail_ == -1) {
@@ -263,12 +270,8 @@ public:
       ++head_;
     }
   }
-  inline const std::pair<int, T> &Front() const noexcept {
-    return buffer_[head_];
-  }
-  inline const std::pair<int, T> &Back() const noexcept {
-    return buffer_[tail_];
-  }
+  inline const Entry &Front() const noexcept { return buffer_[head_]; }
+  inline const Entry &Back() const noexcept { return buffer_[tail_]; }
 
   void Insert(T x) noexcept {
     if constexpr (!SkipNA) {
@@ -288,7 +291,7 @@ public:
       if (std::isnan(x)) {
         // the front can expire on this step even though nothing is inserted;
         // skipping the check leaves an out-of-window entry to be returned
-        if (!Empty() && Front().first <= i_) {
+        if (!Empty() && Front().index <= i_) {
           PopFront();
         }
         ++i_;
@@ -297,10 +300,10 @@ public:
     }
 
     // Valid value: maintain monotonic deque
-    while (!Empty() && comp_(Back().second, x)) {
+    while (!Empty() && comp_(Back().value, x)) {
       PopBack();
     }
-    if (!Empty() && Front().first <= i_) {
+    if (!Empty() && Front().index <= i_) {
       PopFront();
     }
     PushBack(window_size_ + i_, x);
@@ -317,7 +320,7 @@ public:
     }
     if (Empty())
       return std::numeric_limits<T>::quiet_NaN();
-    return Front().second;
+    return Front().value;
   }
 
   T Update(T new_x, T) noexcept {
@@ -328,11 +331,11 @@ public:
     }
     if (Empty())
       return std::numeric_limits<T>::quiet_NaN();
-    return Front().second;
+    return Front().value;
   }
 
 private:
-  std::vector<std::pair<int, T>> buffer_;
+  std::unique_ptr<Entry[]> buffer_;
   int window_size_;
   int head_ = 0;
   int tail_ = -1;

--- a/include/coreforecast/scalers.h
+++ b/include/coreforecast/scalers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "brent.h"
+#include "common.h"
 #include "stats.h"
 
 #include <Eigen/Dense>
@@ -123,6 +124,7 @@ T BoxCox_GuerreroCV(T lambda, const std::vector<T> &x_mean,
 template <typename T>
 void BoxCoxLambdaGuerrero(const T *x, int n, T *out, int period, T lower,
                           T upper) {
+  RequirePositive("season_length", period);
   if (n <= 2 * period) {
     *out = T{1.0};
     return;

--- a/include/coreforecast/scalers.h
+++ b/include/coreforecast/scalers.h
@@ -6,7 +6,9 @@
 #include <Eigen/Dense>
 
 #include <algorithm>
+#include <cmath>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <ranges>
 #include <vector>

--- a/include/coreforecast/scalers.h
+++ b/include/coreforecast/scalers.h
@@ -24,14 +24,6 @@ inline T CommonScalerInverseTransform(T data, T offset, T scale) {
   return data * scale + offset;
 }
 
-template <typename T> inline std::vector<T> DropNaN(const T *data, int n) {
-  std::vector<T> out;
-  out.reserve(n);
-  std::copy_if(data, data + n, std::back_inserter(out),
-               [](T x) { return !std::isnan(x); });
-  return out;
-}
-
 // Applies stats_fn to the data, or to a NaN-free copy of it when skipna is set,
 // writing NaN stats when nothing valid remains.
 template <typename T, typename Fn>
@@ -41,7 +33,10 @@ inline void WithSkipNA(const T *data, int n, T *stats, bool skipna,
     stats_fn(data, n, stats);
     return;
   }
-  const std::vector<T> valid = DropNaN(data, n);
+  std::vector<T> valid;
+  valid.reserve(n);
+  std::copy_if(data, data + n, std::back_inserter(valid),
+               [](T x) { return !std::isnan(x); });
   if (valid.empty()) {
     stats[0] = std::numeric_limits<T>::quiet_NaN();
     stats[1] = std::numeric_limits<T>::quiet_NaN();

--- a/include/coreforecast/scalers.h
+++ b/include/coreforecast/scalers.h
@@ -6,7 +6,9 @@
 #include <Eigen/Dense>
 
 #include <algorithm>
+#include <iterator>
 #include <numeric>
+#include <ranges>
 #include <vector>
 
 namespace scalers {
@@ -20,129 +22,80 @@ inline T CommonScalerInverseTransform(T data, T offset, T scale) {
   return data * scale + offset;
 }
 
+template <typename T> inline std::vector<T> DropNaN(const T *data, int n) {
+  std::vector<T> out;
+  out.reserve(n);
+  std::copy_if(data, data + n, std::back_inserter(out),
+               [](T x) { return !std::isnan(x); });
+  return out;
+}
+
+// Applies stats_fn to the data, or to a NaN-free copy of it when skipna is set,
+// writing NaN stats when nothing valid remains.
+template <typename T, typename Fn>
+inline void WithSkipNA(const T *data, int n, T *stats, bool skipna,
+                       Fn stats_fn) {
+  if (!skipna) {
+    stats_fn(data, n, stats);
+    return;
+  }
+  const std::vector<T> valid = DropNaN(data, n);
+  if (valid.empty()) {
+    stats[0] = std::numeric_limits<T>::quiet_NaN();
+    stats[1] = std::numeric_limits<T>::quiet_NaN();
+    return;
+  }
+  stats_fn(valid.data(), static_cast<int>(valid.size()), stats);
+}
+
 template <typename T>
 inline void MinMaxScalerStats(const T *data, int n, T *stats,
                               bool skipna = false) {
-  if (!skipna) {
-    auto [min, max] =
-        std::ranges::minmax(std::ranges::subrange(data, data + n));
-    stats[0] = min;
-    stats[1] = max - min;
-  } else {
-    std::vector<T> valid_data;
-    for (int i = 0; i < n; ++i) {
-      if (!std::isnan(data[i])) {
-        valid_data.push_back(data[i]);
-      }
-    }
-    if (valid_data.empty()) {
-      stats[0] = std::numeric_limits<T>::quiet_NaN();
-      stats[1] = std::numeric_limits<T>::quiet_NaN();
-    } else {
-      auto [min, max] = std::ranges::minmax(valid_data);
-      stats[0] = min;
-      stats[1] = max - min;
-    }
-  }
+  WithSkipNA(data, n, stats, skipna, [](const T *d, int m, T *s) {
+    auto [min, max] = std::ranges::minmax(std::ranges::subrange(d, d + m));
+    s[0] = min;
+    s[1] = max - min;
+  });
 }
 
 template <typename T>
 inline void StandardScalerStats(const T *data, int n, T *stats,
                                 bool skipna = false) {
-  if (!skipna) {
-    const Eigen::Map<const Eigen::Vector<T, Eigen::Dynamic>> v(data, n);
+  WithSkipNA(data, n, stats, skipna, [](const T *d, int m, T *s) {
+    const Eigen::Map<const Eigen::Vector<T, Eigen::Dynamic>> v(d, m);
     auto double_v = v.template cast<double>().array();
     double mean = double_v.mean();
     double std = std::sqrt((double_v - mean).square().mean());
-    stats[0] = static_cast<T>(mean);
-    stats[1] = static_cast<T>(std);
-  } else {
-    std::vector<T> valid_data;
-    for (int i = 0; i < n; ++i) {
-      if (!std::isnan(data[i])) {
-        valid_data.push_back(data[i]);
-      }
-    }
-    if (valid_data.empty()) {
-      stats[0] = std::numeric_limits<T>::quiet_NaN();
-      stats[1] = std::numeric_limits<T>::quiet_NaN();
-    } else {
-      const Eigen::Map<const Eigen::Vector<T, Eigen::Dynamic>> v(
-          valid_data.data(), valid_data.size());
-      auto double_v = v.template cast<double>().array();
-      double mean = double_v.mean();
-      double std = std::sqrt((double_v - mean).square().mean());
-      stats[0] = static_cast<T>(mean);
-      stats[1] = static_cast<T>(std);
-    }
-  }
+    s[0] = static_cast<T>(mean);
+    s[1] = static_cast<T>(std);
+  });
 }
 
 template <typename T>
 inline void RobustScalerIqrStats(const T *data, int n, T *stats,
                                  bool skipna = false) {
-  if (!skipna) {
-    std::vector<T> buffer(data, data + n);
+  WithSkipNA(data, n, stats, skipna, [](const T *d, int m, T *s) {
+    std::vector<T> buffer(d, d + m);
     const T q1 = stats::Quantile(buffer.begin(), buffer.end(), T{0.25});
     const T median = stats::Quantile(buffer.begin(), buffer.end(), T{0.5});
     const T q3 = stats::Quantile(buffer.begin(), buffer.end(), T{0.75});
-    stats[0] = median;
-    stats[1] = q3 - q1;
-  } else {
-    std::vector<T> valid_data;
-    for (int i = 0; i < n; ++i) {
-      if (!std::isnan(data[i])) {
-        valid_data.push_back(data[i]);
-      }
-    }
-    if (valid_data.empty()) {
-      stats[0] = std::numeric_limits<T>::quiet_NaN();
-      stats[1] = std::numeric_limits<T>::quiet_NaN();
-    } else {
-      const T q1 =
-          stats::Quantile(valid_data.begin(), valid_data.end(), T{0.25});
-      const T median =
-          stats::Quantile(valid_data.begin(), valid_data.end(), T{0.5});
-      const T q3 =
-          stats::Quantile(valid_data.begin(), valid_data.end(), T{0.75});
-      stats[0] = median;
-      stats[1] = q3 - q1;
-    }
-  }
+    s[0] = median;
+    s[1] = q3 - q1;
+  });
 }
 
 template <typename T>
 inline void RobustScalerMadStats(const T *data, int n, T *stats,
                                  bool skipna = false) {
-  if (!skipna) {
-    std::vector<T> buffer(data, data + n);
+  WithSkipNA(data, n, stats, skipna, [](const T *d, int m, T *s) {
+    std::vector<T> buffer(d, d + m);
     const T median = stats::Quantile(buffer.begin(), buffer.end(), T{0.5});
     std::transform(buffer.begin(), buffer.end(), buffer.begin(),
                    [median](auto x) { return std::abs(x - median); });
     const T mad = stats::Quantile(buffer.begin(), buffer.end(), T{0.5});
-    stats[0] = median;
-    stats[1] = mad;
-  } else {
-    std::vector<T> valid_data;
-    for (int i = 0; i < n; ++i) {
-      if (!std::isnan(data[i])) {
-        valid_data.push_back(data[i]);
-      }
-    }
-    if (valid_data.empty()) {
-      stats[0] = std::numeric_limits<T>::quiet_NaN();
-      stats[1] = std::numeric_limits<T>::quiet_NaN();
-    } else {
-      const T median =
-          stats::Quantile(valid_data.begin(), valid_data.end(), T{0.5});
-      std::transform(valid_data.begin(), valid_data.end(), valid_data.begin(),
-                     [median](auto x) { return std::abs(x - median); });
-      const T mad =
-          stats::Quantile(valid_data.begin(), valid_data.end(), T{0.5});
-      stats[0] = median;
-      stats[1] = mad;
-    }
-  }
+    s[0] = median;
+    s[1] = mad;
+  });
 }
 
 template <typename T>

--- a/include/coreforecast/seasonal.h
+++ b/include/coreforecast/seasonal.h
@@ -51,7 +51,7 @@ void GreatestAutocovariance(const T *x, size_t n, T *out, size_t max_lag) {
   Eigen::VectorX<T> resids(n);
   Difference(x, n, resids.data(), 1);
   indptr_t start = FirstNotNaN(resids.data(), n);
-  if (start == n) {
+  if (static_cast<size_t>(start) == n) {
     *out = T{0};
     return;
   }

--- a/python/coreforecast/lag_transforms.py
+++ b/python/coreforecast/lag_transforms.py
@@ -31,7 +31,16 @@ if TYPE_CHECKING:
 
 
 class _BaseLagTransform(abc.ABC):
+    lag: int
     stats_: np.ndarray
+
+    @property
+    def _update_lag(self) -> int:
+        # an update consumes the value that isn't in ga yet, so it reads one
+        # position further back than the transform does
+        if self.lag < 1:
+            raise ValueError(f"lag must be greater than 0 to update, got {self.lag}")
+        return self.lag - 1
 
     @abc.abstractmethod
     def transform(self, ga: "GroupedArray") -> np.ndarray:
@@ -86,12 +95,11 @@ class Lag(_BaseLagTransform):
         return ga._lag(self.lag)
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
-        return ga._index_from_end(self.lag - 1)
+        return ga._index_from_end(self._update_lag)
 
 
 class _RollingBase(_BaseLagTransform):
     stat_name: str
-    lag: int
     window_size: int
     min_samples: int
     skipna: bool
@@ -119,7 +127,7 @@ class _RollingBase(_BaseLagTransform):
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
         return getattr(ga, f"_rolling_{self.stat_name}_update")(
-            self.lag - 1, self.window_size, self.min_samples, self.skipna
+            self._update_lag, self.window_size, self.min_samples, self.skipna
         )
 
 
@@ -211,7 +219,7 @@ class RollingQuantile(_RollingBase):
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
         return ga._rolling_quantile_update(
-            self.lag - 1, self.p, self.window_size, self.min_samples, self.skipna
+            self._update_lag, self.p, self.window_size, self.min_samples, self.skipna
         )
 
 
@@ -240,7 +248,7 @@ class _SeasonalRollingBase(_RollingBase):
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
         return getattr(ga, f"_seasonal_rolling_{self.stat_name}_update")(
-            self.lag - 1,
+            self._update_lag,
             self.season_length,
             self.window_size,
             self.min_samples,
@@ -351,7 +359,7 @@ class SeasonalRollingQuantile(_SeasonalRollingBase):
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
         return ga._seasonal_rolling_quantile_update(
-            self.lag - 1,
+            self._update_lag,
             self.p,
             self.season_length,
             self.window_size,
@@ -389,8 +397,9 @@ class ExpandingMean(_ExpandingBase):
         return out
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
+        x = ga._index_from_end(self._update_lag)
         self.stats_[:, 0] += 1.0
-        self.stats_[:, 1] += ga._index_from_end(self.lag - 1)
+        self.stats_[:, 1] += x
         return self.stats_[:, 1] / self.stats_[:, 0]
 
 
@@ -407,7 +416,7 @@ class ExpandingStd(_ExpandingBase):
         return out
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
-        x = ga._index_from_end(self.lag - 1)
+        x = ga._index_from_end(self._update_lag)
         self.stats_[:, 0] += 1.0
         n = self.stats_[:, 0]
         prev_avg = self.stats_[:, 1].copy()
@@ -427,7 +436,7 @@ class _ExpandingComp(_ExpandingBase):
         return out
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
-        self.stats_ = self._comp_fn(self.stats_, ga._index_from_end(self.lag - 1))
+        self.stats_ = self._comp_fn(self.stats_, ga._index_from_end(self._update_lag))
         return self.stats_
 
 
@@ -475,7 +484,7 @@ class ExpandingQuantile(_BaseLagTransform):
         return ga._expanding_quantile(self.lag, self.p, self.skipna)
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
-        return ga._expanding_quantile_update(self.lag - 1, self.p, self.skipna)
+        return ga._expanding_quantile_update(self._update_lag, self.p, self.skipna)
 
 
 class ExponentiallyWeightedMean(_BaseLagTransform):
@@ -498,7 +507,7 @@ class ExponentiallyWeightedMean(_BaseLagTransform):
         return out
 
     def update(self, ga: "GroupedArray") -> np.ndarray:
-        x = ga._index_from_end(self.lag - 1)
+        x = ga._index_from_end(self._update_lag)
         self.stats_ = self.alpha * x + (1 - self.alpha) * self.stats_
         return self.stats_
 

--- a/python/coreforecast/rolling.py
+++ b/python/coreforecast/rolling.py
@@ -84,9 +84,10 @@ def _seasonal_rolling_docstring(*args, **kwargs) -> Callable:
         skipna (bool, optional): Exclude NaN values from calculations. When False (default),
             NaNs are assumed to occur only as a leading run: that prefix is preserved in the
             output and the statistic is computed over the values that follow it. A NaN
-            anywhere else makes that result and every later one NaN. When True, NaN values
-            are ignored and statistics are computed on remaining valid values in the window,
-            which is what you want for data with gaps in the middle.
+            anywhere else makes that result and every later one in the same season NaN;
+            the other seasons are unaffected. When True, NaN values are ignored and
+            statistics are computed on remaining valid values in the window, which is
+            what you want for data with gaps in the middle.
             Defaults to False for backwards compatibility.
 
     Returns:
@@ -243,9 +244,10 @@ def seasonal_rolling_quantile(
         skipna (bool, optional): Exclude NaN values from calculations. When False (default),
             NaNs are assumed to occur only as a leading run: that prefix is preserved in the
             output and the statistic is computed over the values that follow it. A NaN
-            anywhere else makes that result and every later one NaN. When True, NaN values
-            are ignored and statistics are computed on remaining valid values in the window,
-            which is what you want for data with gaps in the middle.
+            anywhere else makes that result and every later one in the same season NaN;
+            the other seasons are unaffected. When True, NaN values are ignored and
+            statistics are computed on remaining valid values in the window, which is
+            what you want for data with gaps in the middle.
             Defaults to False for backwards compatibility.
 
     Returns:

--- a/python/coreforecast/rolling.py
+++ b/python/coreforecast/rolling.py
@@ -54,8 +54,11 @@ def _rolling_docstring(*args, **kwargs) -> Callable:
         min_samples (int, optional): The minimum number of samples required to compute the statistic.
             If None, it is set to `window_size`.
         skipna (bool, optional): Exclude NaN values from calculations. When False (default),
-            any NaN value in the window causes the result to be NaN. When True, NaN values
-            are ignored and statistics are computed on remaining valid values in the window.
+            NaNs are assumed to occur only as a leading run: that prefix is preserved in the
+            output and the statistic is computed over the values that follow it. A NaN
+            anywhere else makes that result and every later one NaN. When True, NaN values
+            are ignored and statistics are computed on remaining valid values in the window,
+            which is what you want for data with gaps in the middle.
             Defaults to False for backwards compatibility.
 
     Returns:
@@ -79,8 +82,11 @@ def _seasonal_rolling_docstring(*args, **kwargs) -> Callable:
         min_samples (int, optional): The minimum number of samples required to compute the statistic.
             If None, it is set to `window_size`.
         skipna (bool, optional): Exclude NaN values from calculations. When False (default),
-            any NaN value in the window causes the result to be NaN. When True, NaN values
-            are ignored and statistics are computed on remaining valid values in the window.
+            NaNs are assumed to occur only as a leading run: that prefix is preserved in the
+            output and the statistic is computed over the values that follow it. A NaN
+            anywhere else makes that result and every later one NaN. When True, NaN values
+            are ignored and statistics are computed on remaining valid values in the window,
+            which is what you want for data with gaps in the middle.
             Defaults to False for backwards compatibility.
 
     Returns:
@@ -150,8 +156,11 @@ def rolling_quantile(
         min_samples (int, optional): The minimum number of samples required to compute the statistic.
             If None, it is set to `window_size`.
         skipna (bool, optional): Exclude NaN values from calculations. When False (default),
-            any NaN value in the window causes the result to be NaN. When True, NaN values
-            are ignored and statistics are computed on remaining valid values in the window.
+            NaNs are assumed to occur only as a leading run: that prefix is preserved in the
+            output and the statistic is computed over the values that follow it. A NaN
+            anywhere else makes that result and every later one NaN. When True, NaN values
+            are ignored and statistics are computed on remaining valid values in the window,
+            which is what you want for data with gaps in the middle.
             Defaults to False for backwards compatibility.
 
     Returns:
@@ -232,8 +241,11 @@ def seasonal_rolling_quantile(
         min_samples (int, optional): The minimum number of samples required to compute the statistic.
             If None, it is set to `window_size`.
         skipna (bool, optional): Exclude NaN values from calculations. When False (default),
-            any NaN value in the window causes the result to be NaN. When True, NaN values
-            are ignored and statistics are computed on remaining valid values in the window.
+            NaNs are assumed to occur only as a leading run: that prefix is preserved in the
+            output and the statistic is computed over the values that follow it. A NaN
+            anywhere else makes that result and every later one NaN. When True, NaN values
+            are ignored and statistics are computed on remaining valid values in the window,
+            which is what you want for data with gaps in the middle.
             Defaults to False for backwards compatibility.
 
     Returns:

--- a/python/coreforecast/scalers.py
+++ b/python/coreforecast/scalers.py
@@ -43,8 +43,11 @@ def _boxcox_lambda_checks(
         )
     if lower >= upper:
         raise ValueError("lower must be less than upper")
-    if method == "guerrero" and season_length is None:
-        raise ValueError("season_length is required when method='guerrero'")
+    if method == "guerrero":
+        if season_length is None:
+            raise ValueError("season_length is required when method='guerrero'")
+        if season_length <= 0:
+            raise ValueError("season_length must be greater than 0")
 
 
 def boxcox_lambda(
@@ -180,7 +183,8 @@ class LocalMinMaxScaler(_BaseLocalScaler):
 
     Args:
         skipna (bool): If True, exclude NaN values when computing statistics.
-            When False (default), NaN values are included and may result in NaN statistics."""
+            When False (default), only a leading run of NaNs is supported; an
+            interior one leaves the statistics unspecified, so pass True for that."""
 
     _scaler_type = "minmax"
 
@@ -193,7 +197,8 @@ class LocalStandardScaler(_BaseLocalScaler):
 
     Args:
         skipna (bool): If True, exclude NaN values when computing statistics.
-            When False (default), NaN values are included and may result in NaN statistics."""
+            When False (default), only a leading run of NaNs is supported; an
+            interior one leaves the statistics unspecified, so pass True for that."""
 
     _scaler_type = "standard"
 
@@ -209,7 +214,8 @@ class LocalRobustScaler(_BaseLocalScaler):
             If 'iqr' will use the inter quartile range as the scale.
             If 'mad' will use median absolute deviation as the scale.
         skipna (bool): If True, exclude NaN values when computing statistics.
-            When False (default), NaN values are included and may result in NaN statistics."""
+            When False (default), only a leading run of NaNs is supported; an
+            interior one leaves the statistics unspecified, so pass True for that."""
 
     def __init__(self, scale: str, skipna: bool = False):
         if scale == "iqr":

--- a/src/diff.cpp
+++ b/src/diff.cpp
@@ -20,6 +20,7 @@ int NumSeasDiffs(const py::array_t<T> data, int period, int max_d) {
 
 template <typename T>
 py::array_t<T> Difference(const py::array_t<T> data, int d) {
+  RequireNonNegative("d", d);
   const auto x = AsContiguous(data);
   py::array_t<T> out(x.size());
   seasonal::Difference(x.data(), x.size(), out.mutable_data(), d);

--- a/src/diff.cpp
+++ b/src/diff.cpp
@@ -31,6 +31,6 @@ template <typename T> void init_diffs_fns(py::module_ &m) {
 
 void init_diffs(py::module_ &m) {
   py::module_ diffs = m.def_submodule("differences");
-  init_diffs_fns<float>(diffs);
   init_diffs_fns<double>(diffs);
+  init_diffs_fns<float>(diffs);
 }

--- a/src/diff.cpp
+++ b/src/diff.cpp
@@ -5,21 +5,24 @@
 
 template <typename T> int NumDiffs(const py::array_t<T> data, int max_d) {
   T out;
-  diff::NumDiffs(data.data(), data.size(), &out, max_d);
+  const auto x = AsContiguous(data);
+  diff::NumDiffs(x.data(), x.size(), &out, max_d);
   return static_cast<int>(out);
 }
 
 template <typename T>
 int NumSeasDiffs(const py::array_t<T> data, int period, int max_d) {
   T out;
-  diff::NumSeasDiffs(data.data(), data.size(), &out, period, max_d);
+  const auto x = AsContiguous(data);
+  diff::NumSeasDiffs(x.data(), x.size(), &out, period, max_d);
   return static_cast<int>(out);
 }
 
 template <typename T>
 py::array_t<T> Difference(const py::array_t<T> data, int d) {
-  py::array_t<T> out(data.size());
-  seasonal::Difference(data.data(), data.size(), out.mutable_data(), d);
+  const auto x = AsContiguous(data);
+  py::array_t<T> out(x.size());
+  seasonal::Difference(x.data(), x.size(), out.mutable_data(), d);
   return out;
 }
 

--- a/src/expanding.cpp
+++ b/src/expanding.cpp
@@ -53,6 +53,6 @@ template <typename T> void init_exp_fns(py::module_ &m) {
 
 void init_exp(py::module_ &m) {
   py::module_ exp = m.def_submodule("expanding");
-  init_exp_fns<float>(exp);
   init_exp_fns<double>(exp);
+  init_exp_fns<float>(exp);
 }

--- a/src/expanding.cpp
+++ b/src/expanding.cpp
@@ -35,6 +35,7 @@ py::array_t<T> ExpandingMax(const py::array_t<T> data, bool skipna = false) {
 template <typename T>
 py::array_t<T> ExpandingQuantile(const py::array_t<T> data, T p,
                                  bool skipna = false) {
+  rolling::RequireProbability("p", p);
   return ExpandingOp(expanding::QuantileTransform<T>, data, p, skipna);
 }
 

--- a/src/expanding.cpp
+++ b/src/expanding.cpp
@@ -5,9 +5,9 @@
 
 template <typename T, typename Func, typename... Args>
 py::array_t<T> ExpandingOp(Func f, const py::array_t<T> data, Args... args) {
-  py::array_t<T> out(data.size());
-  f(data.data(), data.size(), out.mutable_data(), std::forward<Args>(args)...);
-  return out;
+  return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
+    f(d, n, o, std::forward<Args>(args)...);
+  });
 }
 
 template <typename T>

--- a/src/exponentially_weighted.cpp
+++ b/src/exponentially_weighted.cpp
@@ -6,10 +6,9 @@ template <typename T>
 py::array_t<T> ExponentiallyWeightedMean(
     const py::array_t<T, py::array::c_style | py::array::forcecast> data,
     T alpha, bool skipna = false) {
-  py::array_t<T> out(data.size());
-  exponentially_weighted::MeanTransform<T>(data.data(), data.size(),
-                                           out.mutable_data(), alpha, skipna);
-  return out;
+  return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
+    exponentially_weighted::MeanTransform<T>(d, n, o, alpha, skipna);
+  });
 }
 
 void init_ew(py::module_ &m) {

--- a/src/exponentially_weighted.cpp
+++ b/src/exponentially_weighted.cpp
@@ -3,9 +3,8 @@
 #include "exponentially_weighted.h"
 
 template <typename T>
-py::array_t<T> ExponentiallyWeightedMean(
-    const py::array_t<T, py::array::c_style | py::array::forcecast> data,
-    T alpha, bool skipna = false) {
+py::array_t<T> ExponentiallyWeightedMean(const py::array_t<T> data, T alpha,
+                                         bool skipna = false) {
   return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
     exponentially_weighted::MeanTransform<T>(d, n, o, alpha, skipna);
   });

--- a/src/exponentially_weighted.cpp
+++ b/src/exponentially_weighted.cpp
@@ -14,8 +14,8 @@ py::array_t<T> ExponentiallyWeightedMean(
 
 void init_ew(py::module_ &m) {
   py::module_ ew = m.def_submodule("exponentially_weighted");
-  ew.def("exponentially_weighted_mean", &ExponentiallyWeightedMean<float>,
-         py::arg("data"), py::arg("alpha"), py::arg("skipna") = false);
   ew.def("exponentially_weighted_mean", &ExponentiallyWeightedMean<double>,
+         py::arg("data"), py::arg("alpha"), py::arg("skipna") = false);
+  ew.def("exponentially_weighted_mean", &ExponentiallyWeightedMean<float>,
          py::arg("data"), py::arg("alpha"), py::arg("skipna") = false);
 }

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -18,6 +18,31 @@
 
 using namespace pybind11::literals;
 
+// Entries used as offsets into a buffer: a negative one makes a slice start
+// before it and a decreasing one makes a slice run backwards.
+template <typename T>
+inline void RequireOffsets(const T *values, py::ssize_t size) {
+  for (py::ssize_t i = 0; i < size; ++i) {
+    if (values[i] < 0) {
+      throw std::invalid_argument("indptr values must be non-negative");
+    }
+    if (i > 0 && values[i] < values[i - 1]) {
+      throw std::invalid_argument("indptr must be non-decreasing");
+    }
+  }
+}
+
+// One difference order per group, used both as a loop bound and to build the
+// tails offsets, so a short array is read past its end.
+inline void CheckDs(const CArray<indptr_t> &ds, int n_groups) {
+  if (ds.size() != n_groups) {
+    throw std::invalid_argument("ds must have one element per group");
+  }
+  for (py::ssize_t i = 0; i < ds.size(); ++i) {
+    RequireNonNegative("d", ds.data()[i]);
+  }
+}
+
 template <typename T> inline void SkipLags(T *out, int n, int lag) {
   int replacements = std::min(lag, n);
   for (int i = 0; i < replacements; ++i) {
@@ -312,6 +337,11 @@ public:
                                              num_threads_);
   }
   py::array_t<T> Tails(const CArray<indptr_t> out_indptr) {
+    if (out_indptr.size() != indptr_.size()) {
+      throw std::invalid_argument(
+          "indptr must have one element per group plus one");
+    }
+    RequireOffsets(out_indptr.data(), out_indptr.size());
     py::array_t<T> out(out_indptr.data()[NumGroups()]);
     VariableReduce(grouped_array_functions::Tail<T>, out_indptr.data(),
                    out.mutable_data());
@@ -632,9 +662,7 @@ public:
     return out;
   }
   py::array_t<T> Differences(const CArray<indptr_t> ds) {
-    for (py::ssize_t i = 0; i < ds.size(); ++i) {
-      RequireNonNegative("d", ds.data()[i]);
-    }
+    CheckDs(ds, NumGroups());
     py::array_t<T> out(data_.size());
     VariableTransform(diff::Differences<T>, ds.data(), out.mutable_data());
     return out;
@@ -646,12 +674,20 @@ public:
   }
   py::array_t<T> InvertDifferences(const CArray<indptr_t> ds,
                                    const CArray<T> tails) {
+    CheckDs(ds, NumGroups());
     py::array_t<indptr_t> tails_indptr(indptr_.size());
     auto ds_data = ds.data();
     auto tails_indptr_data = tails_indptr.mutable_data();
     tails_indptr_data[0] = 0;
     for (int i = 1; i < tails_indptr.size(); ++i) {
       tails_indptr_data[i] = tails_indptr_data[i - 1] + ds_data[i - 1];
+    }
+    // tails_ga is built here rather than through the factory, so the check the
+    // factory would have done on its last offset has to happen here.
+    if (static_cast<py::ssize_t>(tails_indptr_data[tails_indptr.size() - 1]) !=
+        tails.size()) {
+      throw std::invalid_argument(
+          "tails must have as many elements as the sum of ds");
     }
     auto tails_ga = GroupedArray<T>(tails, tails_indptr, num_threads_);
     py::array_t<T> out(data_.size());
@@ -682,15 +718,12 @@ inline py::array_t<indptr_t> CheckedIndptr(const py::object &indptr,
   }
   const int64_t *values = indptr64.data();
   for (py::ssize_t i = 0; i < indptr64.size(); ++i) {
-    if (values[i] < 0 || values[i] > std::numeric_limits<indptr_t>::max()) {
+    if (values[i] > std::numeric_limits<indptr_t>::max()) {
       throw std::invalid_argument(
-          "indptr values must be non-negative and representable with 32-bit "
-          "integers");
-    }
-    if (i > 0 && values[i] < values[i - 1]) {
-      throw std::invalid_argument("indptr must be non-decreasing");
+          "indptr values must be representable with 32-bit integers");
     }
   }
+  RequireOffsets(values, indptr64.size());
   if (data_size != values[indptr64.size() - 1]) {
     throw std::invalid_argument(
         "Last element of indptr must be equal to the size of data");

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -18,14 +18,6 @@
 
 using namespace pybind11::literals;
 
-// A negative lag makes the transforms below write before the start of the
-// output buffer, so it is rejected once per call rather than per group.
-inline void RequireNonNegative(const char *name, int value) {
-  if (value < 0) {
-    throw std::invalid_argument(std::string(name) + " must be non-negative");
-  }
-}
-
 template <typename T> inline void SkipLags(T *out, int n, int lag) {
   int replacements = std::min(lag, n);
   for (int i = 0; i < replacements; ++i) {
@@ -68,8 +60,12 @@ public:
   py::array_t<T> Take(const CArray<indptr_t> indices) const {
     auto indices_data = indices.data();
     auto indptr_data = indptr_.data();
+    const indptr_t num_groups = NumGroups();
     indptr_t out_size = 0;
     for (int i = 0; i < indices.size(); ++i) {
+      if (indices_data[i] < 0 || indices_data[i] >= num_groups) {
+        throw std::out_of_range("Index out of range");
+      }
       indptr_t start = indptr_data[indices_data[i]];
       indptr_t end = indptr_data[indices_data[i] + 1];
       out_size += end - start;
@@ -244,8 +240,13 @@ public:
         indptr_t n = end - start;
         indptr_t start_idx = FirstNotNaN(data + start, n, out + start);
         SkipLags(out + start + start_idx, n - start_idx, lag);
-        if (start_idx + lag >= n)
+        if (start_idx + lag >= n) {
+          // f never runs for an empty or all-NaN group, so its stats row would
+          // otherwise be left uninitialised.
+          std::fill(agg + i * n_agg, agg + (i + 1) * n_agg,
+                    std::numeric_limits<T>::quiet_NaN());
           continue;
+        }
         start += start_idx;
         f(data + start, n - start_idx - lag, out + start + lag, agg + i * n_agg,
           std::forward<Args>(args)...);
@@ -625,11 +626,15 @@ public:
     return out;
   }
   py::array_t<T> Difference(int d) {
+    RequireNonNegative("d", d);
     py::array_t<T> out(data_.size());
     Transform(seasonal::Difference<T>, 0, out.mutable_data(), d);
     return out;
   }
   py::array_t<T> Differences(const CArray<indptr_t> ds) {
+    for (py::ssize_t i = 0; i < ds.size(); ++i) {
+      RequireNonNegative("d", ds.data()[i]);
+    }
     py::array_t<T> out(data_.size());
     VariableTransform(diff::Differences<T>, ds.data(), out.mutable_data());
     return out;

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -794,11 +794,22 @@ void init_ga(py::module_ &m) {
         if (!indptr64) {
           throw std::invalid_argument("indptr must be an integer array");
         }
-        int64_t last_indptr = indptr64.data()[indptr64.size() - 1];
-        if (last_indptr > std::numeric_limits<indptr_t>::max()) {
-          throw std::invalid_argument(
-              "indptr is too large to be represented with 32-bit integers");
+        // every entry is used as an offset into data, so all of them have to
+        // be representable and describe a non-decreasing range, not just the
+        // last one
+        const int64_t *indptr_data = indptr64.data();
+        for (py::ssize_t i = 0; i < indptr64.size(); ++i) {
+          if (indptr_data[i] < 0 ||
+              indptr_data[i] > std::numeric_limits<indptr_t>::max()) {
+            throw std::invalid_argument(
+                "indptr values must be non-negative and representable with "
+                "32-bit integers");
+          }
+          if (i > 0 && indptr_data[i] < indptr_data[i - 1]) {
+            throw std::invalid_argument("indptr must be non-decreasing");
+          }
         }
+        int64_t last_indptr = indptr_data[indptr64.size() - 1];
         if (data.size() != last_indptr) {
           throw std::invalid_argument(
               "Last element of indptr must be equal to the size of data");

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -1,4 +1,8 @@
+#include <algorithm>
+#include <exception>
 #include <limits>
+#include <thread>
+#include <vector>
 
 #include "common.h"
 #include "diff.h"
@@ -72,28 +76,57 @@ public:
     return out;
   }
 
-  template <typename Func> void ForEach(Func f) const noexcept {
-    if (num_threads_ < 2) {
-      f(0, NumGroups());
+  // The workers only touch raw buffers, never the Python API, so the GIL is
+  // released around them. Exceptions can't cross a thread boundary, so each
+  // worker stashes its own and we rethrow once everything has been joined.
+  template <typename Func> void ForEach(Func f) const {
+    const int n_groups = NumGroups();
+    const int n_threads = std::clamp(num_threads_, 1, std::max(1, n_groups));
+    if (n_threads < 2) {
+      py::gil_scoped_release release;
+      f(0, n_groups);
       return;
     }
+    std::vector<std::exception_ptr> errors(n_threads);
     std::vector<std::thread> threads;
-    threads.reserve(num_threads_);
-    int groups_per_thread = NumGroups() / num_threads_;
-    int remainder = NumGroups() % num_threads_;
-    for (int t = 0; t < num_threads_; ++t) {
-      int start_group = t * groups_per_thread + std::min(t, remainder);
-      int end_group = (t + 1) * groups_per_thread + std::min(t + 1, remainder);
-      threads.emplace_back(f, start_group, end_group);
+    threads.reserve(n_threads);
+    const int groups_per_thread = n_groups / n_threads;
+    const int remainder = n_groups % n_threads;
+    std::exception_ptr spawn_error;
+    {
+      py::gil_scoped_release release;
+      try {
+        for (int t = 0; t < n_threads; ++t) {
+          int start_group = t * groups_per_thread + std::min(t, remainder);
+          int end_group =
+              (t + 1) * groups_per_thread + std::min(t + 1, remainder);
+          threads.emplace_back([&f, &errors, t, start_group, end_group]() {
+            try {
+              f(start_group, end_group);
+            } catch (...) {
+              errors[t] = std::current_exception();
+            }
+          });
+        }
+      } catch (...) {
+        spawn_error = std::current_exception();
+      }
+      for (auto &thread : threads) {
+        thread.join();
+      }
     }
-    for (auto &thread : threads) {
-      thread.join();
+    if (spawn_error) {
+      std::rethrow_exception(spawn_error);
+    }
+    for (auto &error : errors) {
+      if (error) {
+        std::rethrow_exception(error);
+      }
     }
   }
 
   template <typename Func, typename... Args>
-  void Reduce(Func f, int n_out, T *out, int lag,
-              Args &&...args) const noexcept {
+  void Reduce(Func f, int n_out, T *out, int lag, Args &&...args) const {
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, n_out, out, lag,
              &args...](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -116,7 +149,7 @@ public:
 
   template <typename Func, typename... Args>
   void VariableReduce(Func f, const indptr_t *indptr_out, T *out,
-                      Args &&...args) const noexcept {
+                      Args &&...args) const {
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, indptr_out, out,
              &args...](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -131,7 +164,7 @@ public:
   }
 
   template <typename Func>
-  void ScalerTransform(Func f, const T *stats, T *out) const noexcept {
+  void ScalerTransform(Func f, const T *stats, T *out) const {
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, stats,
              out](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -150,7 +183,7 @@ public:
   }
 
   template <typename Func, typename... Args>
-  void Transform(Func f, int lag, T *out, Args &&...args) const noexcept {
+  void Transform(Func f, int lag, T *out, Args &&...args) const {
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, lag, out,
              &args...](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -170,8 +203,7 @@ public:
   }
 
   template <typename Func>
-  void VariableTransform(Func f, const indptr_t *params,
-                         T *out) const noexcept {
+  void VariableTransform(Func f, const indptr_t *params, T *out) const {
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, params,
              out](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -190,7 +222,7 @@ public:
 
   template <typename Func, typename... Args>
   void TransformAndReduce(Func f, int lag, T *out, int n_agg, T *agg,
-                          Args &&...args) const noexcept {
+                          Args &&...args) const {
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, lag, out, n_agg,
              agg, &args...](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -210,7 +242,7 @@ public:
 
   template <typename Func>
   void Zip(Func f, const GroupedArray<T> &other, const indptr_t *out_indptr,
-           T *out) const noexcept {
+           T *out) const {
     ForEach([data = data_.data(), indptr = indptr_.data(), &f,
              other_data = other.data_.data(),
              other_indptr = other.indptr_.data(), out_indptr,
@@ -495,92 +527,20 @@ public:
   template <typename Func>
   py::array_t<T> ScalerStats(Func func, bool skipna = false) {
     py::array_t<T> out({static_cast<int>(NumGroups()), 2});
-    // Use Reduce with skipna as last parameter
     Reduce(func, 2, out.mutable_data(), 0, skipna);
     return out;
   }
   py::array_t<T> MinMaxScalerStats(bool skipna = false) {
-    py::array_t<T> out({static_cast<int>(NumGroups()), 2});
-    // Directly call Reduce with skipna for scaler stats
-    ForEach([data = data_.data(), indptr = indptr_.data(), skipna,
-             &out](int start_group, int end_group) {
-      for (int i = start_group; i < end_group; ++i) {
-        indptr_t start = indptr[i];
-        indptr_t end = indptr[i + 1];
-        indptr_t n = end - start;
-        indptr_t start_idx = FirstNotNaN(data + start, n);
-        if (start_idx >= n) {
-          out.mutable_data()[2 * i] = std::numeric_limits<T>::quiet_NaN();
-          out.mutable_data()[2 * i + 1] = std::numeric_limits<T>::quiet_NaN();
-          continue;
-        }
-        scalers::MinMaxScalerStats<T>(data + start + start_idx, n - start_idx,
-                                      out.mutable_data() + 2 * i, skipna);
-      }
-    });
-    return out;
+    return ScalerStats(scalers::MinMaxScalerStats<T>, skipna);
   }
   py::array_t<T> StandardScalerStats(bool skipna = false) {
-    py::array_t<T> out({static_cast<int>(NumGroups()), 2});
-    ForEach([data = data_.data(), indptr = indptr_.data(), skipna,
-             &out](int start_group, int end_group) {
-      for (int i = start_group; i < end_group; ++i) {
-        indptr_t start = indptr[i];
-        indptr_t end = indptr[i + 1];
-        indptr_t n = end - start;
-        indptr_t start_idx = FirstNotNaN(data + start, n);
-        if (start_idx >= n) {
-          out.mutable_data()[2 * i] = std::numeric_limits<T>::quiet_NaN();
-          out.mutable_data()[2 * i + 1] = std::numeric_limits<T>::quiet_NaN();
-          continue;
-        }
-        scalers::StandardScalerStats<T>(data + start + start_idx, n - start_idx,
-                                        out.mutable_data() + 2 * i, skipna);
-      }
-    });
-    return out;
+    return ScalerStats(scalers::StandardScalerStats<T>, skipna);
   }
   py::array_t<T> RobustIqrScalerStats(bool skipna = false) {
-    py::array_t<T> out({static_cast<int>(NumGroups()), 2});
-    ForEach([data = data_.data(), indptr = indptr_.data(), skipna,
-             &out](int start_group, int end_group) {
-      for (int i = start_group; i < end_group; ++i) {
-        indptr_t start = indptr[i];
-        indptr_t end = indptr[i + 1];
-        indptr_t n = end - start;
-        indptr_t start_idx = FirstNotNaN(data + start, n);
-        if (start_idx >= n) {
-          out.mutable_data()[2 * i] = std::numeric_limits<T>::quiet_NaN();
-          out.mutable_data()[2 * i + 1] = std::numeric_limits<T>::quiet_NaN();
-          continue;
-        }
-        scalers::RobustScalerIqrStats<T>(data + start + start_idx,
-                                         n - start_idx,
-                                         out.mutable_data() + 2 * i, skipna);
-      }
-    });
-    return out;
+    return ScalerStats(scalers::RobustScalerIqrStats<T>, skipna);
   }
   py::array_t<T> RobustMadScalerStats(bool skipna = false) {
-    py::array_t<T> out({static_cast<int>(NumGroups()), 2});
-    ForEach([data = data_.data(), indptr = indptr_.data(), skipna,
-             &out](int start_group, int end_group) {
-      for (int i = start_group; i < end_group; ++i) {
-        indptr_t start = indptr[i];
-        indptr_t end = indptr[i + 1];
-        indptr_t n = end - start;
-        indptr_t start_idx = FirstNotNaN(data + start, n);
-        if (start_idx >= n) {
-          out.mutable_data()[2 * i] = std::numeric_limits<T>::quiet_NaN();
-          out.mutable_data()[2 * i + 1] = std::numeric_limits<T>::quiet_NaN();
-          continue;
-        }
-        scalers::RobustScalerMadStats<T>(data + start + start_idx,
-                                         n - start_idx,
-                                         out.mutable_data() + 2 * i, skipna);
-      }
-    });
-    return out;
+    return ScalerStats(scalers::RobustScalerMadStats<T>, skipna);
   }
   py::array_t<T> ApplyScaler(const py::array_t<T> stats) {
     py::array_t<T> out(data_.size());
@@ -816,21 +776,35 @@ void init_ga(py::module_ &m) {
   bind_ga<double>(ga, "_GroupedArrayFloat64");
   ga.def(
       "GroupedArray",
-      [](py::array data,
-         py::array_t<indptr_t, py::array::c_style | py::array::forcecast>
-             indptr,
-         int num_threads) -> py::object {
+      [](py::array data, py::array indptr_arg, int num_threads) -> py::object {
         if (data.ndim() != 1) {
           throw std::invalid_argument("data must be a 1d array");
         }
-        if (indptr.ndim() != 1) {
+        if (indptr_arg.ndim() != 1) {
           throw std::invalid_argument("indptr must be a 1d array");
         }
-        indptr_t last_indptr = indptr.data()[indptr.size() - 1];
+        if (indptr_arg.size() < 1) {
+          throw std::invalid_argument("indptr must have at least one element");
+        }
+        // indptr_t is 32 bit, so validate in 64 bit first: casting straight to
+        // indptr_t would wrap a too-large value into one that can still compare
+        // equal to the size of data
+        auto indptr64 = py::array_t < int64_t,
+             py::array::c_style | py::array::forcecast > ::ensure(indptr_arg);
+        if (!indptr64) {
+          throw std::invalid_argument("indptr must be an integer array");
+        }
+        int64_t last_indptr = indptr64.data()[indptr64.size() - 1];
+        if (last_indptr > std::numeric_limits<indptr_t>::max()) {
+          throw std::invalid_argument(
+              "indptr is too large to be represented with 32-bit integers");
+        }
         if (data.size() != last_indptr) {
           throw std::invalid_argument(
               "Last element of indptr must be equal to the size of data");
         }
+        auto indptr = py::array_t < indptr_t,
+             py::array::c_style | py::array::forcecast > (indptr64);
         data = py::array::ensure(data, py::array::c_style);
         if (data.dtype().kind() != 'f') {
           data = data.attr("astype")("float32");

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <exception>
 #include <limits>
+#include <stdexcept>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -15,6 +17,14 @@
 #include "seasonal.h"
 
 using namespace pybind11::literals;
+
+// A negative lag makes the transforms below write before the start of the
+// output buffer, so it is rejected once per call rather than per group.
+inline void RequireNonNegative(const char *name, int value) {
+  if (value < 0) {
+    throw std::invalid_argument(std::string(name) + " must be non-negative");
+  }
+}
 
 template <typename T> inline void SkipLags(T *out, int n, int lag) {
   int replacements = std::min(lag, n);
@@ -127,6 +137,7 @@ public:
 
   template <typename Func, typename... Args>
   void Reduce(Func f, int n_out, T *out, int lag, Args &&...args) const {
+    RequireNonNegative("lag", lag);
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, n_out, out, lag,
              &args...](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -184,6 +195,7 @@ public:
 
   template <typename Func, typename... Args>
   void Transform(Func f, int lag, T *out, Args &&...args) const {
+    RequireNonNegative("lag", lag);
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, lag, out,
              &args...](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -223,6 +235,7 @@ public:
   template <typename Func, typename... Args>
   void TransformAndReduce(Func f, int lag, T *out, int n_agg, T *agg,
                           Args &&...args) const {
+    RequireNonNegative("lag", lag);
     ForEach([data = data_.data(), indptr = indptr_.data(), &f, lag, out, n_agg,
              agg, &args...](int start_group, int end_group) {
       for (int i = start_group; i < end_group; ++i) {
@@ -304,48 +317,42 @@ public:
     return out;
   }
 
-  py::array_t<T> LagTransform(uint32_t lag) {
+  py::array_t<T> LagTransform(int lag) {
     py::array_t<T> out(data_.size());
     Transform(lag::LagTransform<T>, lag, out.mutable_data());
     return out;
   }
 
   template <typename Func>
-  py::array_t<T> RollingTransform(Func transform, uint32_t lag,
-                                  uint32_t window_size, uint32_t min_samples,
-                                  bool skipna = false) {
+  py::array_t<T> RollingTransform(Func transform, int lag, int window_size,
+                                  int min_samples, bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(transform, lag, out.mutable_data(), window_size, min_samples,
               skipna);
     return out;
   }
-  py::array_t<T> RollingMeanTransform(uint32_t lag, uint32_t window_size,
-                                      uint32_t min_samples,
+  py::array_t<T> RollingMeanTransform(int lag, int window_size, int min_samples,
                                       bool skipna = false) {
     return RollingTransform(rolling::MeanTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingStdTransform(uint32_t lag, uint32_t window_size,
-                                     uint32_t min_samples,
+  py::array_t<T> RollingStdTransform(int lag, int window_size, int min_samples,
                                      bool skipna = false) {
     return RollingTransform(rolling::StdTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingMinTransform(uint32_t lag, uint32_t window_size,
-                                     uint32_t min_samples,
+  py::array_t<T> RollingMinTransform(int lag, int window_size, int min_samples,
                                      bool skipna = false) {
     return RollingTransform(rolling::MinTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingMaxTransform(uint32_t lag, uint32_t window_size,
-                                     uint32_t min_samples,
+  py::array_t<T> RollingMaxTransform(int lag, int window_size, int min_samples,
                                      bool skipna = false) {
     return RollingTransform(rolling::MaxTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingQuantileTransform(uint32_t lag, T p,
-                                          uint32_t window_size,
-                                          uint32_t min_samples,
+  py::array_t<T> RollingQuantileTransform(int lag, T p, int window_size,
+                                          int min_samples,
                                           bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(rolling::QuantileTransform<T>, lag, out.mutable_data(),
@@ -354,37 +361,35 @@ public:
   }
 
   template <typename Func>
-  py::array_t<T> RollingUpdate(Func transform, uint32_t lag,
-                               uint32_t window_size, uint32_t min_samples,
-                               bool skipna = false) {
+  py::array_t<T> RollingUpdate(Func transform, int lag, int window_size,
+                               int min_samples, bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(transform, 1, out.mutable_data(), lag, window_size, min_samples,
            skipna);
     return out;
   }
-  py::array_t<T> RollingMeanUpdate(uint32_t lag, uint32_t window_size,
-                                   uint32_t min_samples, bool skipna = false) {
+  py::array_t<T> RollingMeanUpdate(int lag, int window_size, int min_samples,
+                                   bool skipna = false) {
     return RollingUpdate(rolling::MeanUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingStdUpdate(uint32_t lag, uint32_t window_size,
-                                  uint32_t min_samples, bool skipna = false) {
+  py::array_t<T> RollingStdUpdate(int lag, int window_size, int min_samples,
+                                  bool skipna = false) {
     return RollingUpdate(rolling::StdUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingMaxUpdate(uint32_t lag, uint32_t window_size,
-                                  uint32_t min_samples, bool skipna = false) {
+  py::array_t<T> RollingMaxUpdate(int lag, int window_size, int min_samples,
+                                  bool skipna = false) {
     return RollingUpdate(rolling::MaxUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingMinUpdate(uint32_t lag, uint32_t window_size,
-                                  uint32_t min_samples, bool skipna = false) {
+  py::array_t<T> RollingMinUpdate(int lag, int window_size, int min_samples,
+                                  bool skipna = false) {
     return RollingUpdate(rolling::MinUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingQuantileUpdate(uint32_t lag, T p, uint32_t window_size,
-                                       uint32_t min_samples,
-                                       bool skipna = false) {
+  py::array_t<T> RollingQuantileUpdate(int lag, T p, int window_size,
+                                       int min_samples, bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(rolling::QuantileUpdate<T>, 1, out.mutable_data(), lag, window_size,
            min_samples, p, skipna);
@@ -392,55 +397,47 @@ public:
   }
 
   template <typename Func>
-  py::array_t<T>
-  SeasonalRollingTransform(Func transform, uint32_t lag, uint32_t season_length,
-                           uint32_t window_size, uint32_t min_samples,
-                           bool skipna = false) {
+  py::array_t<T> SeasonalRollingTransform(Func transform, int lag,
+                                          int season_length, int window_size,
+                                          int min_samples,
+                                          bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(transform, lag, out.mutable_data(), season_length, window_size,
               min_samples, skipna);
     return out;
   }
-  py::array_t<T> SeasonalRollingMeanTransform(uint32_t lag,
-                                              uint32_t season_length,
-                                              uint32_t window_size,
-                                              uint32_t min_samples,
+  py::array_t<T> SeasonalRollingMeanTransform(int lag, int season_length,
+                                              int window_size, int min_samples,
                                               bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalMeanTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingStdTransform(uint32_t lag,
-                                             uint32_t season_length,
-                                             uint32_t window_size,
-                                             uint32_t min_samples,
+  py::array_t<T> SeasonalRollingStdTransform(int lag, int season_length,
+                                             int window_size, int min_samples,
                                              bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalStdTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingMinTransform(uint32_t lag,
-                                             uint32_t season_length,
-                                             uint32_t window_size,
-                                             uint32_t min_samples,
+  py::array_t<T> SeasonalRollingMinTransform(int lag, int season_length,
+                                             int window_size, int min_samples,
                                              bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalMinTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingMaxTransform(uint32_t lag,
-                                             uint32_t season_length,
-                                             uint32_t window_size,
-                                             uint32_t min_samples,
+  py::array_t<T> SeasonalRollingMaxTransform(int lag, int season_length,
+                                             int window_size, int min_samples,
                                              bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalMaxTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingQuantileTransform(uint32_t lag, T p,
-                                                  uint32_t season_length,
-                                                  uint32_t window_size,
-                                                  uint32_t min_samples,
+  py::array_t<T> SeasonalRollingQuantileTransform(int lag, T p,
+                                                  int season_length,
+                                                  int window_size,
+                                                  int min_samples,
                                                   bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(rolling::SeasonalQuantileTransform<T>, lag, out.mutable_data(),
@@ -449,51 +446,44 @@ public:
   }
 
   template <typename Func>
-  py::array_t<T>
-  SeasonalRollingUpdate(Func transform, uint32_t lag, uint32_t season_length,
-                        uint32_t window_size, uint32_t min_samples,
-                        bool skipna = false) {
+  py::array_t<T> SeasonalRollingUpdate(Func transform, int lag,
+                                       int season_length, int window_size,
+                                       int min_samples, bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(transform, 1, out.mutable_data(), lag, season_length, window_size,
            min_samples, skipna);
     return out;
   }
-  py::array_t<T> SeasonalRollingMeanUpdate(uint32_t lag, uint32_t season_length,
-                                           uint32_t window_size,
-                                           uint32_t min_samples,
+  py::array_t<T> SeasonalRollingMeanUpdate(int lag, int season_length,
+                                           int window_size, int min_samples,
                                            bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalMeanUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingStdUpdate(uint32_t lag, uint32_t season_length,
-                                          uint32_t window_size,
-                                          uint32_t min_samples,
+  py::array_t<T> SeasonalRollingStdUpdate(int lag, int season_length,
+                                          int window_size, int min_samples,
                                           bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalStdUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingMinUpdate(uint32_t lag, uint32_t season_length,
-                                          uint32_t window_size,
-                                          uint32_t min_samples,
+  py::array_t<T> SeasonalRollingMinUpdate(int lag, int season_length,
+                                          int window_size, int min_samples,
                                           bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalMinUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingMaxUpdate(uint32_t lag, uint32_t season_length,
-                                          uint32_t window_size,
-                                          uint32_t min_samples,
+  py::array_t<T> SeasonalRollingMaxUpdate(int lag, int season_length,
+                                          int window_size, int min_samples,
                                           bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalMaxUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingQuantileUpdate(uint32_t lag, T p,
-                                               uint32_t season_length,
-                                               uint32_t window_size,
-                                               uint32_t min_samples,
+  py::array_t<T> SeasonalRollingQuantileUpdate(int lag, T p, int season_length,
+                                               int window_size, int min_samples,
                                                bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(rolling::SeasonalQuantileUpdate<T>, 1, out.mutable_data(), lag,
@@ -502,7 +492,7 @@ public:
   }
 
   std::tuple<py::array_t<T>, py::array_t<T>>
-  ExpandingMeanTransform(uint32_t lag, bool skipna = false) {
+  ExpandingMeanTransform(int lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     py::array_t<T> agg(NumGroups());
     TransformAndReduce(expanding::MeanTransform<T>, lag, out.mutable_data(), 1,
@@ -510,38 +500,36 @@ public:
     return std::make_tuple(out, agg);
   }
   std::tuple<py::array_t<T>, py::array_t<T>>
-  ExpandingStdTransform(uint32_t lag, bool skipna = false) {
+  ExpandingStdTransform(int lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     py::array_t<T> agg({static_cast<int>(NumGroups()), 3});
     TransformAndReduce(expanding::StdTransform<T>, lag, out.mutable_data(), 3,
                        agg.mutable_data(), skipna);
     return std::make_tuple(out, agg);
   }
-  py::array_t<T> ExpandingMinTransform(uint32_t lag, bool skipna = false) {
+  py::array_t<T> ExpandingMinTransform(int lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(expanding::MinTransform<T>, lag, out.mutable_data(), skipna);
     return out;
   }
-  py::array_t<T> ExpandingMaxTransform(uint32_t lag, bool skipna = false) {
+  py::array_t<T> ExpandingMaxTransform(int lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(expanding::MaxTransform<T>, lag, out.mutable_data(), skipna);
     return out;
   }
-  py::array_t<T> ExpandingQuantileTransform(uint32_t lag, T p,
-                                            bool skipna = false) {
+  py::array_t<T> ExpandingQuantileTransform(int lag, T p, bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(expanding::QuantileTransform<T>, lag, out.mutable_data(), p,
               skipna);
     return out;
   }
-  py::array_t<T> ExpandingQuantileUpdate(uint32_t lag, T p,
-                                         bool skipna = false) {
+  py::array_t<T> ExpandingQuantileUpdate(int lag, T p, bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(expanding::QuantileUpdate<T>, 1, out.mutable_data(), lag, p, skipna);
     return out;
   }
 
-  py::array_t<T> ExponentiallyWeightedMeanTransform(uint32_t lag, T alpha,
+  py::array_t<T> ExponentiallyWeightedMeanTransform(int lag, T alpha,
                                                     bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(exponentially_weighted::MeanTransform<T>, lag, out.mutable_data(),

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -55,7 +55,7 @@ public:
                           static_cast<T *>(buffer.ptr) + start, data_);
   }
 
-  py::array_t<T> Take(const py::array_t<indptr_t> indices) const {
+  py::array_t<T> Take(const CArray<indptr_t> indices) const {
     auto indices_data = indices.data();
     auto indptr_data = indptr_.data();
     indptr_t out_size = 0;
@@ -260,7 +260,7 @@ public:
     });
   }
 
-  std::unique_ptr<GroupedArray<T>> WithData(const py::array_t<T> new_data) {
+  std::unique_ptr<GroupedArray<T>> WithData(const CArray<T> new_data) {
     if (new_data.size() != data_.size()) {
       throw std::invalid_argument("Data must have the same size");
     }
@@ -297,49 +297,55 @@ public:
     return std::make_unique<GroupedArray<T>>(out_data, out_indptr,
                                              num_threads_);
   }
-  py::array_t<T> Tails(py::array_t<indptr_t> out_indptr) {
+  py::array_t<T> Tails(const CArray<indptr_t> out_indptr) {
     py::array_t<T> out(out_indptr.data()[NumGroups()]);
     VariableReduce(grouped_array_functions::Tail<T>, out_indptr.data(),
                    out.mutable_data());
     return out;
   }
 
-  py::array_t<T> LagTransform(int lag) {
+  py::array_t<T> LagTransform(uint32_t lag) {
     py::array_t<T> out(data_.size());
     Transform(lag::LagTransform<T>, lag, out.mutable_data());
     return out;
   }
 
   template <typename Func>
-  py::array_t<T> RollingTransform(Func transform, int lag, int window_size,
-                                  int min_samples, bool skipna = false) {
+  py::array_t<T> RollingTransform(Func transform, uint32_t lag,
+                                  uint32_t window_size, uint32_t min_samples,
+                                  bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(transform, lag, out.mutable_data(), window_size, min_samples,
               skipna);
     return out;
   }
-  py::array_t<T> RollingMeanTransform(int lag, int window_size, int min_samples,
+  py::array_t<T> RollingMeanTransform(uint32_t lag, uint32_t window_size,
+                                      uint32_t min_samples,
                                       bool skipna = false) {
     return RollingTransform(rolling::MeanTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingStdTransform(int lag, int window_size, int min_samples,
+  py::array_t<T> RollingStdTransform(uint32_t lag, uint32_t window_size,
+                                     uint32_t min_samples,
                                      bool skipna = false) {
     return RollingTransform(rolling::StdTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingMinTransform(int lag, int window_size, int min_samples,
+  py::array_t<T> RollingMinTransform(uint32_t lag, uint32_t window_size,
+                                     uint32_t min_samples,
                                      bool skipna = false) {
     return RollingTransform(rolling::MinTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingMaxTransform(int lag, int window_size, int min_samples,
+  py::array_t<T> RollingMaxTransform(uint32_t lag, uint32_t window_size,
+                                     uint32_t min_samples,
                                      bool skipna = false) {
     return RollingTransform(rolling::MaxTransform<T>, lag, window_size,
                             min_samples, skipna);
   }
-  py::array_t<T> RollingQuantileTransform(int lag, T p, int window_size,
-                                          int min_samples,
+  py::array_t<T> RollingQuantileTransform(uint32_t lag, T p,
+                                          uint32_t window_size,
+                                          uint32_t min_samples,
                                           bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(rolling::QuantileTransform<T>, lag, out.mutable_data(),
@@ -348,35 +354,37 @@ public:
   }
 
   template <typename Func>
-  py::array_t<T> RollingUpdate(Func transform, int lag, int window_size,
-                               int min_samples, bool skipna = false) {
+  py::array_t<T> RollingUpdate(Func transform, uint32_t lag,
+                               uint32_t window_size, uint32_t min_samples,
+                               bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(transform, 1, out.mutable_data(), lag, window_size, min_samples,
            skipna);
     return out;
   }
-  py::array_t<T> RollingMeanUpdate(int lag, int window_size, int min_samples,
-                                   bool skipna = false) {
+  py::array_t<T> RollingMeanUpdate(uint32_t lag, uint32_t window_size,
+                                   uint32_t min_samples, bool skipna = false) {
     return RollingUpdate(rolling::MeanUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingStdUpdate(int lag, int window_size, int min_samples,
-                                  bool skipna = false) {
+  py::array_t<T> RollingStdUpdate(uint32_t lag, uint32_t window_size,
+                                  uint32_t min_samples, bool skipna = false) {
     return RollingUpdate(rolling::StdUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingMaxUpdate(int lag, int window_size, int min_samples,
-                                  bool skipna = false) {
+  py::array_t<T> RollingMaxUpdate(uint32_t lag, uint32_t window_size,
+                                  uint32_t min_samples, bool skipna = false) {
     return RollingUpdate(rolling::MaxUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingMinUpdate(int lag, int window_size, int min_samples,
-                                  bool skipna = false) {
+  py::array_t<T> RollingMinUpdate(uint32_t lag, uint32_t window_size,
+                                  uint32_t min_samples, bool skipna = false) {
     return RollingUpdate(rolling::MinUpdate<T>, lag, window_size, min_samples,
                          skipna);
   }
-  py::array_t<T> RollingQuantileUpdate(int lag, T p, int window_size,
-                                       int min_samples, bool skipna = false) {
+  py::array_t<T> RollingQuantileUpdate(uint32_t lag, T p, uint32_t window_size,
+                                       uint32_t min_samples,
+                                       bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(rolling::QuantileUpdate<T>, 1, out.mutable_data(), lag, window_size,
            min_samples, p, skipna);
@@ -384,47 +392,55 @@ public:
   }
 
   template <typename Func>
-  py::array_t<T> SeasonalRollingTransform(Func transform, int lag,
-                                          int season_length, int window_size,
-                                          int min_samples,
-                                          bool skipna = false) {
+  py::array_t<T>
+  SeasonalRollingTransform(Func transform, uint32_t lag, uint32_t season_length,
+                           uint32_t window_size, uint32_t min_samples,
+                           bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(transform, lag, out.mutable_data(), season_length, window_size,
               min_samples, skipna);
     return out;
   }
-  py::array_t<T> SeasonalRollingMeanTransform(int lag, int season_length,
-                                              int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingMeanTransform(uint32_t lag,
+                                              uint32_t season_length,
+                                              uint32_t window_size,
+                                              uint32_t min_samples,
                                               bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalMeanTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingStdTransform(int lag, int season_length,
-                                             int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingStdTransform(uint32_t lag,
+                                             uint32_t season_length,
+                                             uint32_t window_size,
+                                             uint32_t min_samples,
                                              bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalStdTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingMinTransform(int lag, int season_length,
-                                             int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingMinTransform(uint32_t lag,
+                                             uint32_t season_length,
+                                             uint32_t window_size,
+                                             uint32_t min_samples,
                                              bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalMinTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingMaxTransform(int lag, int season_length,
-                                             int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingMaxTransform(uint32_t lag,
+                                             uint32_t season_length,
+                                             uint32_t window_size,
+                                             uint32_t min_samples,
                                              bool skipna = false) {
     return SeasonalRollingTransform(rolling::SeasonalMaxTransform<T>, lag,
                                     season_length, window_size, min_samples,
                                     skipna);
   }
-  py::array_t<T> SeasonalRollingQuantileTransform(int lag, T p,
-                                                  int season_length,
-                                                  int window_size,
-                                                  int min_samples,
+  py::array_t<T> SeasonalRollingQuantileTransform(uint32_t lag, T p,
+                                                  uint32_t season_length,
+                                                  uint32_t window_size,
+                                                  uint32_t min_samples,
                                                   bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(rolling::SeasonalQuantileTransform<T>, lag, out.mutable_data(),
@@ -433,44 +449,51 @@ public:
   }
 
   template <typename Func>
-  py::array_t<T> SeasonalRollingUpdate(Func transform, int lag,
-                                       int season_length, int window_size,
-                                       int min_samples, bool skipna = false) {
+  py::array_t<T>
+  SeasonalRollingUpdate(Func transform, uint32_t lag, uint32_t season_length,
+                        uint32_t window_size, uint32_t min_samples,
+                        bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(transform, 1, out.mutable_data(), lag, season_length, window_size,
            min_samples, skipna);
     return out;
   }
-  py::array_t<T> SeasonalRollingMeanUpdate(int lag, int season_length,
-                                           int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingMeanUpdate(uint32_t lag, uint32_t season_length,
+                                           uint32_t window_size,
+                                           uint32_t min_samples,
                                            bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalMeanUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingStdUpdate(int lag, int season_length,
-                                          int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingStdUpdate(uint32_t lag, uint32_t season_length,
+                                          uint32_t window_size,
+                                          uint32_t min_samples,
                                           bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalStdUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingMinUpdate(int lag, int season_length,
-                                          int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingMinUpdate(uint32_t lag, uint32_t season_length,
+                                          uint32_t window_size,
+                                          uint32_t min_samples,
                                           bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalMinUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingMaxUpdate(int lag, int season_length,
-                                          int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingMaxUpdate(uint32_t lag, uint32_t season_length,
+                                          uint32_t window_size,
+                                          uint32_t min_samples,
                                           bool skipna = false) {
     return SeasonalRollingUpdate(rolling::SeasonalMaxUpdate<T>, lag,
                                  season_length, window_size, min_samples,
                                  skipna);
   }
-  py::array_t<T> SeasonalRollingQuantileUpdate(int lag, T p, int season_length,
-                                               int window_size, int min_samples,
+  py::array_t<T> SeasonalRollingQuantileUpdate(uint32_t lag, T p,
+                                               uint32_t season_length,
+                                               uint32_t window_size,
+                                               uint32_t min_samples,
                                                bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(rolling::SeasonalQuantileUpdate<T>, 1, out.mutable_data(), lag,
@@ -479,7 +502,7 @@ public:
   }
 
   std::tuple<py::array_t<T>, py::array_t<T>>
-  ExpandingMeanTransform(int lag, bool skipna = false) {
+  ExpandingMeanTransform(uint32_t lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     py::array_t<T> agg(NumGroups());
     TransformAndReduce(expanding::MeanTransform<T>, lag, out.mutable_data(), 1,
@@ -487,36 +510,38 @@ public:
     return std::make_tuple(out, agg);
   }
   std::tuple<py::array_t<T>, py::array_t<T>>
-  ExpandingStdTransform(int lag, bool skipna = false) {
+  ExpandingStdTransform(uint32_t lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     py::array_t<T> agg({static_cast<int>(NumGroups()), 3});
     TransformAndReduce(expanding::StdTransform<T>, lag, out.mutable_data(), 3,
                        agg.mutable_data(), skipna);
     return std::make_tuple(out, agg);
   }
-  py::array_t<T> ExpandingMinTransform(int lag, bool skipna = false) {
+  py::array_t<T> ExpandingMinTransform(uint32_t lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(expanding::MinTransform<T>, lag, out.mutable_data(), skipna);
     return out;
   }
-  py::array_t<T> ExpandingMaxTransform(int lag, bool skipna = false) {
+  py::array_t<T> ExpandingMaxTransform(uint32_t lag, bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(expanding::MaxTransform<T>, lag, out.mutable_data(), skipna);
     return out;
   }
-  py::array_t<T> ExpandingQuantileTransform(int lag, T p, bool skipna = false) {
+  py::array_t<T> ExpandingQuantileTransform(uint32_t lag, T p,
+                                            bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(expanding::QuantileTransform<T>, lag, out.mutable_data(), p,
               skipna);
     return out;
   }
-  py::array_t<T> ExpandingQuantileUpdate(int lag, T p, bool skipna = false) {
+  py::array_t<T> ExpandingQuantileUpdate(uint32_t lag, T p,
+                                         bool skipna = false) {
     py::array_t<T> out(NumGroups());
     Reduce(expanding::QuantileUpdate<T>, 1, out.mutable_data(), lag, p, skipna);
     return out;
   }
 
-  py::array_t<T> ExponentiallyWeightedMeanTransform(int lag, T alpha,
+  py::array_t<T> ExponentiallyWeightedMeanTransform(uint32_t lag, T alpha,
                                                     bool skipna = false) {
     py::array_t<T> out(data_.size());
     Transform(exponentially_weighted::MeanTransform<T>, lag, out.mutable_data(),
@@ -542,13 +567,13 @@ public:
   py::array_t<T> RobustMadScalerStats(bool skipna = false) {
     return ScalerStats(scalers::RobustScalerMadStats<T>, skipna);
   }
-  py::array_t<T> ApplyScaler(const py::array_t<T> stats) {
+  py::array_t<T> ApplyScaler(const CArray<T> stats) {
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::CommonScalerTransform<T>, stats.data(),
                     out.mutable_data());
     return out;
   }
-  py::array_t<T> InvertScaler(const py::array_t<T> stats) {
+  py::array_t<T> InvertScaler(const CArray<T> stats) {
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::CommonScalerInverseTransform<T>, stats.data(),
                     out.mutable_data());
@@ -566,13 +591,13 @@ public:
            upper);
     return out;
   }
-  py::array_t<T> BoxCoxTransform(const py::array_t<T> lambdas) {
+  py::array_t<T> BoxCoxTransform(const CArray<T> lambdas) {
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::BoxCoxTransform<T>, lambdas.data(),
                     out.mutable_data());
     return out;
   }
-  py::array_t<T> BoxCoxInverseTransform(const py::array_t<T> lambdas) {
+  py::array_t<T> BoxCoxInverseTransform(const CArray<T> lambdas) {
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::BoxCoxInverseTransform<T>, lambdas.data(),
                     out.mutable_data());
@@ -589,7 +614,7 @@ public:
     Reduce(diff::NumSeasDiffs<T>, 1, out.mutable_data(), 0, period, max_d);
     return out;
   }
-  py::array_t<T> NumSeasDiffsPeriods(int max_d, py::array_t<T> periods) {
+  py::array_t<T> NumSeasDiffsPeriods(int max_d, const CArray<T> periods) {
     py::array_t<T> periods_and_out({static_cast<int>(NumGroups()), 2});
     auto periods_ptr = periods.data();
     auto periods_and_out_ptr = periods_and_out.mutable_data();
@@ -616,18 +641,18 @@ public:
     Transform(seasonal::Difference<T>, 0, out.mutable_data(), d);
     return out;
   }
-  py::array_t<T> Differences(const py::array_t<indptr_t> ds) {
+  py::array_t<T> Differences(const CArray<indptr_t> ds) {
     py::array_t<T> out(data_.size());
     VariableTransform(diff::Differences<T>, ds.data(), out.mutable_data());
     return out;
   }
-  py::array_t<T> InvertDifference(int d, const py::array_t<T> tails) {
+  py::array_t<T> InvertDifference(int d, const CArray<T> tails) {
     py::array_t<indptr_t> ds(NumGroups());
     std::fill(ds.mutable_data(), ds.mutable_data() + ds.size(), d);
     return InvertDifferences(ds, tails);
   }
-  py::array_t<T> InvertDifferences(const py::array_t<indptr_t> ds,
-                                   const py::array_t<T> tails) {
+  py::array_t<T> InvertDifferences(const CArray<indptr_t> ds,
+                                   const CArray<T> tails) {
     py::array_t<indptr_t> tails_indptr(indptr_.size());
     auto ds_data = ds.data();
     auto tails_indptr_data = tails_indptr.mutable_data();
@@ -643,10 +668,51 @@ public:
   }
 };
 
+// Validates indptr at the Python boundary and returns it as indptr_t. Every
+// entry is used as an offset into data, so all of them have to be
+// representable and describe a non-decreasing range, not just the last one:
+// casting straight to indptr_t would wrap a too-large value into one that can
+// still compare equal to the size of data. Takes py::object so that lists,
+// tuples and Series keep working, which py::array would reject.
+inline py::array_t<indptr_t> CheckedIndptr(const py::object &indptr,
+                                           py::ssize_t data_size) {
+  auto indptr64 = py::array_t < int64_t,
+       py::array::c_style | py::array::forcecast > ::ensure(indptr);
+  if (!indptr64) {
+    throw std::invalid_argument("indptr must be an integer array");
+  }
+  if (indptr64.ndim() != 1) {
+    throw std::invalid_argument("indptr must be a 1d array");
+  }
+  if (indptr64.size() < 1) {
+    throw std::invalid_argument("indptr must have at least one element");
+  }
+  const int64_t *values = indptr64.data();
+  for (py::ssize_t i = 0; i < indptr64.size(); ++i) {
+    if (values[i] < 0 || values[i] > std::numeric_limits<indptr_t>::max()) {
+      throw std::invalid_argument(
+          "indptr values must be non-negative and representable with 32-bit "
+          "integers");
+    }
+    if (i > 0 && values[i] < values[i - 1]) {
+      throw std::invalid_argument("indptr must be non-decreasing");
+    }
+  }
+  if (data_size != values[indptr64.size() - 1]) {
+    throw std::invalid_argument(
+        "Last element of indptr must be equal to the size of data");
+  }
+  return py::array_t < indptr_t,
+         py::array::c_style | py::array::forcecast > (indptr64);
+}
+
 template <typename T> void bind_ga(py::module &m, const std::string &name) {
   py::class_<GroupedArray<T>>(m, name.c_str())
-      .def(py::init<const py::array_t<T> &, const py::array_t<indptr_t> &,
-                    int>())
+      .def(py::init(
+          [](const CArray<T> &data, const py::object &indptr, int num_threads) {
+            return std::make_unique<GroupedArray<T>>(
+                data, CheckedIndptr(indptr, data.size()), num_threads);
+          }))
       .def_readonly("data", &GroupedArray<T>::data_)
       .def_readonly("indptr", &GroupedArray<T>::indptr_)
       .def_readwrite("num_threads", &GroupedArray<T>::num_threads_)
@@ -776,46 +842,12 @@ void init_ga(py::module_ &m) {
   bind_ga<double>(ga, "_GroupedArrayFloat64");
   ga.def(
       "GroupedArray",
-      [](py::array data, py::array indptr_arg, int num_threads) -> py::object {
+      [](py::array data, const py::object &indptr_arg,
+         int num_threads) -> py::object {
         if (data.ndim() != 1) {
           throw std::invalid_argument("data must be a 1d array");
         }
-        if (indptr_arg.ndim() != 1) {
-          throw std::invalid_argument("indptr must be a 1d array");
-        }
-        if (indptr_arg.size() < 1) {
-          throw std::invalid_argument("indptr must have at least one element");
-        }
-        // indptr_t is 32 bit, so validate in 64 bit first: casting straight to
-        // indptr_t would wrap a too-large value into one that can still compare
-        // equal to the size of data
-        auto indptr64 = py::array_t < int64_t,
-             py::array::c_style | py::array::forcecast > ::ensure(indptr_arg);
-        if (!indptr64) {
-          throw std::invalid_argument("indptr must be an integer array");
-        }
-        // every entry is used as an offset into data, so all of them have to
-        // be representable and describe a non-decreasing range, not just the
-        // last one
-        const int64_t *indptr_data = indptr64.data();
-        for (py::ssize_t i = 0; i < indptr64.size(); ++i) {
-          if (indptr_data[i] < 0 ||
-              indptr_data[i] > std::numeric_limits<indptr_t>::max()) {
-            throw std::invalid_argument(
-                "indptr values must be non-negative and representable with "
-                "32-bit integers");
-          }
-          if (i > 0 && indptr_data[i] < indptr_data[i - 1]) {
-            throw std::invalid_argument("indptr must be non-decreasing");
-          }
-        }
-        int64_t last_indptr = indptr_data[indptr64.size() - 1];
-        if (data.size() != last_indptr) {
-          throw std::invalid_argument(
-              "Last element of indptr must be equal to the size of data");
-        }
-        auto indptr = py::array_t < indptr_t,
-             py::array::c_style | py::array::forcecast > (indptr64);
+        auto indptr = CheckedIndptr(indptr_arg, data.size());
         data = py::array::ensure(data, py::array::c_style);
         if (data.dtype().kind() != 'f') {
           data = data.attr("astype")("float32");

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -358,6 +358,11 @@ public:
           "indptr must have one element per group plus one");
     }
     RequireOffsets(out_indptr.data(), out_indptr.size());
+    // the output is sized from the last offset, so a non-zero first one would
+    // leave the elements before it uninitialized
+    if (out_indptr.data()[0] != 0) {
+      throw std::invalid_argument("First element of indptr must be zero");
+    }
     py::array_t<T> out(out_indptr.data()[NumGroups()]);
     VariableReduce(grouped_array_functions::Tail<T>, out_indptr.data(),
                    out.mutable_data());

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -833,7 +833,7 @@ void init_ga(py::module_ &m) {
         }
         data = py::array::ensure(data, py::array::c_style);
         if (data.dtype().kind() != 'f') {
-          data = data.attr("astype")("float32");
+          data = data.attr("astype")("float64");
         }
         if (py::isinstance<py::array_t<float>>(data)) {
           return py::cast(std::make_unique<GroupedArray<float>>(

--- a/src/grouped_array.cpp
+++ b/src/grouped_array.cpp
@@ -18,6 +18,10 @@
 
 using namespace pybind11::literals;
 
+// The module is built with -fvisibility=hidden, so anything holding a pybind
+// type has to be hidden too; internal linkage is the portable way to say it.
+namespace {
+
 // Entries used as offsets into a buffer: a negative one makes a slice start
 // before it and a decreasing one makes a slice run backwards.
 template <typename T>
@@ -40,6 +44,15 @@ inline void CheckDs(const CArray<indptr_t> &ds, int n_groups) {
   }
   for (py::ssize_t i = 0; i < ds.size(); ++i) {
     RequireNonNegative("d", ds.data()[i]);
+  }
+}
+
+// Two entries per group, read as stats[2 * i] and stats[2 * i + 1], so anything
+// shorter is read past its end.
+template <typename T>
+inline void CheckStats(const CArray<T> &stats, int n_groups) {
+  if (stats.ndim() != 2 || stats.size() != 2 * n_groups) {
+    throw std::invalid_argument("stats must have shape (n_groups, 2)");
   }
 }
 
@@ -307,17 +320,20 @@ public:
   }
 
   py::array_t<T> IndexFromEnd(int k) {
+    RequireNonNegative("k", k);
     py::array_t<T> out(NumGroups());
     Reduce(grouped_array_functions::IndexFromEnd<T>, 1, out.mutable_data(), 0,
            k);
     return out;
   }
   py::array_t<T> Head(int k) {
+    RequireNonNegative("k", k);
     py::array_t<T> out(k * NumGroups());
     Reduce(grouped_array_functions::Head<T>, k, out.mutable_data(), 0, k);
     return out;
   }
   py::array_t<T> Tail(int k) {
+    RequireNonNegative("k", k);
     py::array_t<T> out(k * NumGroups());
     Reduce(grouped_array_functions::Tail<T>, k, out.mutable_data(), 0, k);
     return out;
@@ -385,6 +401,7 @@ public:
   py::array_t<T> RollingQuantileTransform(int lag, T p, int window_size,
                                           int min_samples,
                                           bool skipna = false) {
+    rolling::RequireProbability("p", p);
     py::array_t<T> out(data_.size());
     Transform(rolling::QuantileTransform<T>, lag, out.mutable_data(),
               window_size, min_samples, p, skipna);
@@ -421,6 +438,7 @@ public:
   }
   py::array_t<T> RollingQuantileUpdate(int lag, T p, int window_size,
                                        int min_samples, bool skipna = false) {
+    rolling::RequireProbability("p", p);
     py::array_t<T> out(NumGroups());
     Reduce(rolling::QuantileUpdate<T>, 1, out.mutable_data(), lag, window_size,
            min_samples, p, skipna);
@@ -470,6 +488,7 @@ public:
                                                   int window_size,
                                                   int min_samples,
                                                   bool skipna = false) {
+    rolling::RequireProbability("p", p);
     py::array_t<T> out(data_.size());
     Transform(rolling::SeasonalQuantileTransform<T>, lag, out.mutable_data(),
               season_length, window_size, min_samples, p, skipna);
@@ -516,6 +535,7 @@ public:
   py::array_t<T> SeasonalRollingQuantileUpdate(int lag, T p, int season_length,
                                                int window_size, int min_samples,
                                                bool skipna = false) {
+    rolling::RequireProbability("p", p);
     py::array_t<T> out(NumGroups());
     Reduce(rolling::SeasonalQuantileUpdate<T>, 1, out.mutable_data(), lag,
            season_length, window_size, min_samples, p, skipna);
@@ -549,12 +569,14 @@ public:
     return out;
   }
   py::array_t<T> ExpandingQuantileTransform(int lag, T p, bool skipna = false) {
+    rolling::RequireProbability("p", p);
     py::array_t<T> out(data_.size());
     Transform(expanding::QuantileTransform<T>, lag, out.mutable_data(), p,
               skipna);
     return out;
   }
   py::array_t<T> ExpandingQuantileUpdate(int lag, T p, bool skipna = false) {
+    rolling::RequireProbability("p", p);
     py::array_t<T> out(NumGroups());
     Reduce(expanding::QuantileUpdate<T>, 1, out.mutable_data(), lag, p, skipna);
     return out;
@@ -587,12 +609,14 @@ public:
     return ScalerStats(scalers::RobustScalerMadStats<T>, skipna);
   }
   py::array_t<T> ApplyScaler(const CArray<T> stats) {
+    CheckStats(stats, NumGroups());
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::CommonScalerTransform<T>, stats.data(),
                     out.mutable_data());
     return out;
   }
   py::array_t<T> InvertScaler(const CArray<T> stats) {
+    CheckStats(stats, NumGroups());
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::CommonScalerInverseTransform<T>, stats.data(),
                     out.mutable_data());
@@ -611,12 +635,14 @@ public:
     return out;
   }
   py::array_t<T> BoxCoxTransform(const CArray<T> lambdas) {
+    CheckStats(lambdas, NumGroups());
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::BoxCoxTransform<T>, lambdas.data(),
                     out.mutable_data());
     return out;
   }
   py::array_t<T> BoxCoxInverseTransform(const CArray<T> lambdas) {
+    CheckStats(lambdas, NumGroups());
     py::array_t<T> out(data_.size());
     ScalerTransform(scalers::BoxCoxInverseTransform<T>, lambdas.data(),
                     out.mutable_data());
@@ -634,6 +660,9 @@ public:
     return out;
   }
   py::array_t<T> NumSeasDiffsPeriods(int max_d, const CArray<T> periods) {
+    if (periods.size() != NumGroups()) {
+      throw std::invalid_argument("periods must have one element per group");
+    }
     py::array_t<T> periods_and_out({static_cast<int>(NumGroups()), 2});
     auto periods_ptr = periods.data();
     auto periods_and_out_ptr = periods_and_out.mutable_data();
@@ -861,6 +890,8 @@ template <typename T> void bind_ga(py::module &m, const std::string &name) {
       .def("_inv_diff", &GroupedArray<T>::InvertDifference)
       .def("_inv_diffs", &GroupedArray<T>::InvertDifferences);
 }
+
+} // namespace
 
 void init_ga(py::module_ &m) {
   py::module_ ga = m.def_submodule("grouped_array");

--- a/src/rolling.cpp
+++ b/src/rolling.cpp
@@ -3,45 +3,44 @@
 #include "rolling.h"
 
 template <typename T, typename Func, typename... Args>
-py::array_t<T> RollingOp(Func f, const py::array_t<T> data,
-                         uint32_t window_size, uint32_t min_samples,
-                         Args... args) {
+py::array_t<T> RollingOp(Func f, const py::array_t<T> data, int window_size,
+                         int min_samples, Args... args) {
   return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
     f(d, n, o, window_size, min_samples, std::forward<Args>(args)...);
   });
 }
 
 template <typename T>
-py::array_t<T> RollingMean(const py::array_t<T> data, uint32_t window_size,
-                           uint32_t min_samples, bool skipna = false) {
+py::array_t<T> RollingMean(const py::array_t<T> data, int window_size,
+                           int min_samples, bool skipna = false) {
   return RollingOp(rolling::MeanTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingStd(const py::array_t<T> data, uint32_t window_size,
-                          uint32_t min_samples, bool skipna = false) {
+py::array_t<T> RollingStd(const py::array_t<T> data, int window_size,
+                          int min_samples, bool skipna = false) {
   return RollingOp(rolling::StdTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingMin(const py::array_t<T> data, uint32_t window_size,
-                          uint32_t min_samples, bool skipna = false) {
+py::array_t<T> RollingMin(const py::array_t<T> data, int window_size,
+                          int min_samples, bool skipna = false) {
   return RollingOp(rolling::MinTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingMax(const py::array_t<T> data, uint32_t window_size,
-                          uint32_t min_samples, bool skipna = false) {
+py::array_t<T> RollingMax(const py::array_t<T> data, int window_size,
+                          int min_samples, bool skipna = false) {
   return RollingOp(rolling::MaxTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingQuantile(const py::array_t<T> data, uint32_t window_size,
-                               uint32_t min_samples, T p, bool skipna = false) {
+py::array_t<T> RollingQuantile(const py::array_t<T> data, int window_size,
+                               int min_samples, T p, bool skipna = false) {
   return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
     rolling::QuantileTransform<T>(d, n, o, window_size, min_samples, p, skipna);
   });
@@ -49,8 +48,8 @@ py::array_t<T> RollingQuantile(const py::array_t<T> data, uint32_t window_size,
 
 template <typename T, typename Func, typename... Args>
 py::array_t<T> SeasonalRollingOp(Func f, const py::array_t<T> data,
-                                 uint32_t season_length, uint32_t window_size,
-                                 uint32_t min_samples, Args... args) {
+                                 int season_length, int window_size,
+                                 int min_samples, Args... args) {
   return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
     f(d, n, o, season_length, window_size, min_samples,
       std::forward<Args>(args)...);
@@ -58,42 +57,42 @@ py::array_t<T> SeasonalRollingOp(Func f, const py::array_t<T> data,
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingMean(const py::array_t<T> data,
-                                   uint32_t season_length, uint32_t window_size,
-                                   uint32_t min_samples, bool skipna = false) {
+py::array_t<T> SeasonalRollingMean(const py::array_t<T> data, int season_length,
+                                   int window_size, int min_samples,
+                                   bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalMeanTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingStd(const py::array_t<T> data,
-                                  uint32_t season_length, uint32_t window_size,
-                                  uint32_t min_samples, bool skipna = false) {
+py::array_t<T> SeasonalRollingStd(const py::array_t<T> data, int season_length,
+                                  int window_size, int min_samples,
+                                  bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalStdTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingMin(const py::array_t<T> data,
-                                  uint32_t season_length, uint32_t window_size,
-                                  uint32_t min_samples, bool skipna = false) {
+py::array_t<T> SeasonalRollingMin(const py::array_t<T> data, int season_length,
+                                  int window_size, int min_samples,
+                                  bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalMinTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingMax(const py::array_t<T> data,
-                                  uint32_t season_length, uint32_t window_size,
-                                  uint32_t min_samples, bool skipna = false) {
+py::array_t<T> SeasonalRollingMax(const py::array_t<T> data, int season_length,
+                                  int window_size, int min_samples,
+                                  bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalMaxTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T>
-SeasonalRollingQuantile(const py::array_t<T> data, uint32_t season_length,
-                        uint32_t window_size, uint32_t min_samples, T p,
-                        bool skipna = false) {
+py::array_t<T> SeasonalRollingQuantile(const py::array_t<T> data,
+                                       int season_length, int window_size,
+                                       int min_samples, T p,
+                                       bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalQuantileTransform<T>, data,
                            season_length, window_size, min_samples, p, skipna);
 }

--- a/src/rolling.cpp
+++ b/src/rolling.cpp
@@ -184,8 +184,8 @@ template <typename T> void init_roll_fns(py::module_ &m) {
 
 void init_roll(py::module_ &m) {
   py::module_ roll = m.def_submodule("rolling");
-  init_roll_fns<float>(roll);
   init_roll_fns<double>(roll);
+  init_roll_fns<float>(roll);
 }
 
 // Explicit template instantiations to ensure both SkipNA specializations are

--- a/src/rolling.cpp
+++ b/src/rolling.cpp
@@ -3,44 +3,45 @@
 #include "rolling.h"
 
 template <typename T, typename Func, typename... Args>
-py::array_t<T> RollingOp(Func f, const py::array_t<T> data, int window_size,
-                         int min_samples, Args... args) {
+py::array_t<T> RollingOp(Func f, const py::array_t<T> data,
+                         uint32_t window_size, uint32_t min_samples,
+                         Args... args) {
   return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
     f(d, n, o, window_size, min_samples, std::forward<Args>(args)...);
   });
 }
 
 template <typename T>
-py::array_t<T> RollingMean(const py::array_t<T> data, int window_size,
-                           int min_samples, bool skipna = false) {
+py::array_t<T> RollingMean(const py::array_t<T> data, uint32_t window_size,
+                           uint32_t min_samples, bool skipna = false) {
   return RollingOp(rolling::MeanTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingStd(const py::array_t<T> data, int window_size,
-                          int min_samples, bool skipna = false) {
+py::array_t<T> RollingStd(const py::array_t<T> data, uint32_t window_size,
+                          uint32_t min_samples, bool skipna = false) {
   return RollingOp(rolling::StdTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingMin(const py::array_t<T> data, int window_size,
-                          int min_samples, bool skipna = false) {
+py::array_t<T> RollingMin(const py::array_t<T> data, uint32_t window_size,
+                          uint32_t min_samples, bool skipna = false) {
   return RollingOp(rolling::MinTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingMax(const py::array_t<T> data, int window_size,
-                          int min_samples, bool skipna = false) {
+py::array_t<T> RollingMax(const py::array_t<T> data, uint32_t window_size,
+                          uint32_t min_samples, bool skipna = false) {
   return RollingOp(rolling::MaxTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
-py::array_t<T> RollingQuantile(const py::array_t<T> data, int window_size,
-                               int min_samples, T p, bool skipna = false) {
+py::array_t<T> RollingQuantile(const py::array_t<T> data, uint32_t window_size,
+                               uint32_t min_samples, T p, bool skipna = false) {
   return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
     rolling::QuantileTransform<T>(d, n, o, window_size, min_samples, p, skipna);
   });
@@ -48,8 +49,8 @@ py::array_t<T> RollingQuantile(const py::array_t<T> data, int window_size,
 
 template <typename T, typename Func, typename... Args>
 py::array_t<T> SeasonalRollingOp(Func f, const py::array_t<T> data,
-                                 int season_length, int window_size,
-                                 int min_samples, Args... args) {
+                                 uint32_t season_length, uint32_t window_size,
+                                 uint32_t min_samples, Args... args) {
   return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
     f(d, n, o, season_length, window_size, min_samples,
       std::forward<Args>(args)...);
@@ -57,42 +58,42 @@ py::array_t<T> SeasonalRollingOp(Func f, const py::array_t<T> data,
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingMean(const py::array_t<T> data, int season_length,
-                                   int window_size, int min_samples,
-                                   bool skipna = false) {
+py::array_t<T> SeasonalRollingMean(const py::array_t<T> data,
+                                   uint32_t season_length, uint32_t window_size,
+                                   uint32_t min_samples, bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalMeanTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingStd(const py::array_t<T> data, int season_length,
-                                  int window_size, int min_samples,
-                                  bool skipna = false) {
+py::array_t<T> SeasonalRollingStd(const py::array_t<T> data,
+                                  uint32_t season_length, uint32_t window_size,
+                                  uint32_t min_samples, bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalStdTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingMin(const py::array_t<T> data, int season_length,
-                                  int window_size, int min_samples,
-                                  bool skipna = false) {
+py::array_t<T> SeasonalRollingMin(const py::array_t<T> data,
+                                  uint32_t season_length, uint32_t window_size,
+                                  uint32_t min_samples, bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalMinTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingMax(const py::array_t<T> data, int season_length,
-                                  int window_size, int min_samples,
-                                  bool skipna = false) {
+py::array_t<T> SeasonalRollingMax(const py::array_t<T> data,
+                                  uint32_t season_length, uint32_t window_size,
+                                  uint32_t min_samples, bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalMaxTransform<T>, data,
                            season_length, window_size, min_samples, skipna);
 }
 
 template <typename T>
-py::array_t<T> SeasonalRollingQuantile(const py::array_t<T> data,
-                                       int season_length, int window_size,
-                                       int min_samples, T p,
-                                       bool skipna = false) {
+py::array_t<T>
+SeasonalRollingQuantile(const py::array_t<T> data, uint32_t season_length,
+                        uint32_t window_size, uint32_t min_samples, T p,
+                        bool skipna = false) {
   return SeasonalRollingOp(rolling::SeasonalQuantileTransform<T>, data,
                            season_length, window_size, min_samples, p, skipna);
 }

--- a/src/rolling.cpp
+++ b/src/rolling.cpp
@@ -41,9 +41,8 @@ py::array_t<T> RollingMax(const py::array_t<T> data, int window_size,
 template <typename T>
 py::array_t<T> RollingQuantile(const py::array_t<T> data, int window_size,
                                int min_samples, T p, bool skipna = false) {
-  return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
-    rolling::QuantileTransform<T>(d, n, o, window_size, min_samples, p, skipna);
-  });
+  return RollingOp(rolling::QuantileTransform<T>, data, window_size,
+                   min_samples, p, skipna);
 }
 
 template <typename T, typename Func, typename... Args>

--- a/src/rolling.cpp
+++ b/src/rolling.cpp
@@ -2,59 +2,6 @@
 
 #include "rolling.h"
 
-// Non-inline dispatch functions to ensure correct template selection
-template <typename T>
-void MeanTransformDispatch(const T *data, int n, T *out, int window_size,
-                           int min_samples, bool skipna) {
-  if (skipna) {
-    rolling::Transform<T, rolling::MeanAccumulator<T, true>>(
-        data, n, out, window_size, min_samples);
-  } else {
-    rolling::Transform<T, rolling::MeanAccumulator<T, false>>(
-        data, n, out, window_size, min_samples);
-  }
-}
-
-template <typename T>
-void MinTransformDispatch(const T *data, int n, T *out, int window_size,
-                          int min_samples, bool skipna) {
-  if (skipna) {
-    rolling::Transform<
-        T, rolling::CompAccumulator<T, std::greater_equal<T>, true>>(
-        data, n, out, window_size, min_samples);
-  } else {
-    rolling::Transform<
-        T, rolling::CompAccumulator<T, std::greater_equal<T>, false>>(
-        data, n, out, window_size, min_samples);
-  }
-}
-
-template <typename T>
-void MaxTransformDispatch(const T *data, int n, T *out, int window_size,
-                          int min_samples, bool skipna) {
-  if (skipna) {
-    rolling::Transform<T,
-                       rolling::CompAccumulator<T, std::less_equal<T>, true>>(
-        data, n, out, window_size, min_samples);
-  } else {
-    rolling::Transform<T,
-                       rolling::CompAccumulator<T, std::less_equal<T>, false>>(
-        data, n, out, window_size, min_samples);
-  }
-}
-
-template <typename T>
-void QuantileTransformDispatch(const T *data, int n, T *out, int window_size,
-                               int min_samples, T p, bool skipna) {
-  if (skipna) {
-    rolling::Transform<T, rolling::QuantileAccumulator<T, true>>(
-        data, n, out, window_size, min_samples, p);
-  } else {
-    rolling::Transform<T, rolling::QuantileAccumulator<T, false>>(
-        data, n, out, window_size, min_samples, p);
-  }
-}
-
 template <typename T, typename Func, typename... Args>
 py::array_t<T> RollingOp(Func f, const py::array_t<T> data, int window_size,
                          int min_samples, Args... args) {
@@ -67,7 +14,7 @@ py::array_t<T> RollingOp(Func f, const py::array_t<T> data, int window_size,
 template <typename T>
 py::array_t<T> RollingMean(const py::array_t<T> data, int window_size,
                            int min_samples, bool skipna = false) {
-  return RollingOp(MeanTransformDispatch<T>, data, window_size, min_samples,
+  return RollingOp(rolling::MeanTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
@@ -81,14 +28,14 @@ py::array_t<T> RollingStd(const py::array_t<T> data, int window_size,
 template <typename T>
 py::array_t<T> RollingMin(const py::array_t<T> data, int window_size,
                           int min_samples, bool skipna = false) {
-  return RollingOp(MinTransformDispatch<T>, data, window_size, min_samples,
+  return RollingOp(rolling::MinTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
 template <typename T>
 py::array_t<T> RollingMax(const py::array_t<T> data, int window_size,
                           int min_samples, bool skipna = false) {
-  return RollingOp(MaxTransformDispatch<T>, data, window_size, min_samples,
+  return RollingOp(rolling::MaxTransform<T>, data, window_size, min_samples,
                    skipna);
 }
 
@@ -96,8 +43,8 @@ template <typename T>
 py::array_t<T> RollingQuantile(const py::array_t<T> data, int window_size,
                                int min_samples, T p, bool skipna = false) {
   py::array_t<T> out(data.size());
-  QuantileTransformDispatch<T>(data.data(), data.size(), out.mutable_data(),
-                               window_size, min_samples, p, skipna);
+  rolling::QuantileTransform<T>(data.data(), data.size(), out.mutable_data(),
+                                window_size, min_samples, p, skipna);
   return out;
 }
 
@@ -187,41 +134,3 @@ void init_roll(py::module_ &m) {
   init_roll_fns<float>(roll);
   init_roll_fns<double>(roll);
 }
-
-// Explicit template instantiations to ensure both SkipNA specializations are
-// compiled
-namespace rolling {
-template class MeanAccumulator<float, true>;
-template class MeanAccumulator<float, false>;
-template class MeanAccumulator<double, true>;
-template class MeanAccumulator<double, false>;
-
-template class CompAccumulator<float, std::greater_equal<float>, true>;
-template class CompAccumulator<float, std::greater_equal<float>, false>;
-template class CompAccumulator<float, std::less_equal<float>, true>;
-template class CompAccumulator<float, std::less_equal<float>, false>;
-template class CompAccumulator<double, std::greater_equal<double>, true>;
-template class CompAccumulator<double, std::greater_equal<double>, false>;
-template class CompAccumulator<double, std::less_equal<double>, true>;
-template class CompAccumulator<double, std::less_equal<double>, false>;
-
-template class QuantileAccumulator<float, true>;
-template class QuantileAccumulator<float, false>;
-template class QuantileAccumulator<double, true>;
-template class QuantileAccumulator<double, false>;
-
-// Explicit instantiations of Transform functions
-template void MeanTransform<float>(const float *, int, float *, int, int, bool);
-template void MeanTransform<double>(const double *, int, double *, int, int,
-                                    bool);
-template void MinTransform<float>(const float *, int, float *, int, int, bool);
-template void MinTransform<double>(const double *, int, double *, int, int,
-                                   bool);
-template void MaxTransform<float>(const float *, int, float *, int, int, bool);
-template void MaxTransform<double>(const double *, int, double *, int, int,
-                                   bool);
-template void QuantileTransform<float>(const float *, int, float *, int, int,
-                                       float, bool);
-template void QuantileTransform<double>(const double *, int, double *, int, int,
-                                        double, bool);
-} // namespace rolling

--- a/src/rolling.cpp
+++ b/src/rolling.cpp
@@ -5,10 +5,9 @@
 template <typename T, typename Func, typename... Args>
 py::array_t<T> RollingOp(Func f, const py::array_t<T> data, int window_size,
                          int min_samples, Args... args) {
-  py::array_t<T> out(data.size());
-  f(data.data(), data.size(), out.mutable_data(), window_size, min_samples,
-    std::forward<Args>(args)...);
-  return out;
+  return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
+    f(d, n, o, window_size, min_samples, std::forward<Args>(args)...);
+  });
 }
 
 template <typename T>
@@ -42,20 +41,19 @@ py::array_t<T> RollingMax(const py::array_t<T> data, int window_size,
 template <typename T>
 py::array_t<T> RollingQuantile(const py::array_t<T> data, int window_size,
                                int min_samples, T p, bool skipna = false) {
-  py::array_t<T> out(data.size());
-  rolling::QuantileTransform<T>(data.data(), data.size(), out.mutable_data(),
-                                window_size, min_samples, p, skipna);
-  return out;
+  return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
+    rolling::QuantileTransform<T>(d, n, o, window_size, min_samples, p, skipna);
+  });
 }
 
 template <typename T, typename Func, typename... Args>
 py::array_t<T> SeasonalRollingOp(Func f, const py::array_t<T> data,
                                  int season_length, int window_size,
                                  int min_samples, Args... args) {
-  py::array_t<T> out(data.size());
-  f(data.data(), data.size(), out.mutable_data(), season_length, window_size,
-    min_samples, std::forward<Args>(args)...);
-  return out;
+  return SkipLeadingNaN<T>(data, [&](const T *d, indptr_t n, T *o) {
+    f(d, n, o, season_length, window_size, min_samples,
+      std::forward<Args>(args)...);
+  });
 }
 
 template <typename T>

--- a/src/rolling.cpp
+++ b/src/rolling.cpp
@@ -41,6 +41,7 @@ py::array_t<T> RollingMax(const py::array_t<T> data, int window_size,
 template <typename T>
 py::array_t<T> RollingQuantile(const py::array_t<T> data, int window_size,
                                int min_samples, T p, bool skipna = false) {
+  rolling::RequireProbability("p", p);
   return RollingOp(rolling::QuantileTransform<T>, data, window_size,
                    min_samples, p, skipna);
 }
@@ -92,6 +93,7 @@ py::array_t<T> SeasonalRollingQuantile(const py::array_t<T> data,
                                        int season_length, int window_size,
                                        int min_samples, T p,
                                        bool skipna = false) {
+  rolling::RequireProbability("p", p);
   return SeasonalRollingOp(rolling::SeasonalQuantileTransform<T>, data,
                            season_length, window_size, min_samples, p, skipna);
 }

--- a/src/scalers.cpp
+++ b/src/scalers.cpp
@@ -45,6 +45,6 @@ template <typename T> void init_sc_fns(py::module_ &m) {
 
 void init_sc(py::module_ &m) {
   py::module_ sc = m.def_submodule("scalers");
-  init_sc_fns<float>(sc);
   init_sc_fns<double>(sc);
+  init_sc_fns<float>(sc);
 }

--- a/src/scalers.cpp
+++ b/src/scalers.cpp
@@ -5,31 +5,34 @@
 template <typename T>
 T BoxCoxLambdaGuerrero(py::array_t<T> data, int period, T lower, T upper) {
   T out;
-  scalers::BoxCoxLambdaGuerrero(data.data(), data.size(), &out, period, lower,
-                                upper);
+  const auto x = AsContiguous(data);
+  scalers::BoxCoxLambdaGuerrero(x.data(), x.size(), &out, period, lower, upper);
   return out;
 }
 
 template <typename T>
 T BoxCoxLambdaLogLik(py::array_t<T> data, T lower, T upper) {
   T out;
-  scalers::BoxCoxLambdaLogLik(data.data(), data.size(), &out, lower, upper);
+  const auto x = AsContiguous(data);
+  scalers::BoxCoxLambdaLogLik(x.data(), x.size(), &out, lower, upper);
   return out;
 }
 
 template <typename T>
 py::array_t<T> BoxCoxTransform(py::array_t<T> data, T lambda) {
-  py::array_t<T> out(data.size());
+  const auto in = AsContiguous(data);
+  py::array_t<T> out(in.size());
   std::transform(
-      data.data(), data.data() + data.size(), out.mutable_data(),
+      in.data(), in.data() + in.size(), out.mutable_data(),
       [lambda](T x) { return scalers::BoxCoxTransform<T>(x, lambda, 0.0); });
   return out;
 }
 
 template <typename T>
 py::array_t<T> BoxCoxInverseTransform(const py::array_t<T> data, T lambda) {
-  py::array_t<T> out(data.size());
-  std::transform(data.data(), data.data() + data.size(), out.mutable_data(),
+  const auto in = AsContiguous(data);
+  py::array_t<T> out(in.size());
+  std::transform(in.data(), in.data() + in.size(), out.mutable_data(),
                  [lambda](T x) {
                    return scalers::BoxCoxInverseTransform<T>(x, lambda, 0.0);
                  });

--- a/src/seasonal.cpp
+++ b/src/seasonal.cpp
@@ -11,6 +11,6 @@ template <typename T> int Period(const py::array_t<T> data, size_t max_lag) {
 
 void init_seas(py::module_ &m) {
   py::module_ seas = m.def_submodule("seasonal");
-  seas.def("period", &Period<float>);
   seas.def("period", &Period<double>);
+  seas.def("period", &Period<float>);
 }

--- a/src/seasonal.cpp
+++ b/src/seasonal.cpp
@@ -4,8 +4,9 @@
 
 template <typename T> int Period(const py::array_t<T> data, size_t max_lag) {
   T out;
-  seasonal::GreatestAutocovariance(
-      data.data(), static_cast<size_t>(data.size()), &out, max_lag);
+  const auto x = AsContiguous(data);
+  seasonal::GreatestAutocovariance(x.data(), static_cast<size_t>(x.size()),
+                                   &out, max_lag);
   return static_cast<int>(out);
 }
 

--- a/tests/test_contiguity.py
+++ b/tests/test_contiguity.py
@@ -1,0 +1,130 @@
+"""Non-contiguous input.
+
+The bound parameters take a raw pointer to the input buffer, so without
+c_style a strided view is read as if it were contiguous and silently returns
+results for the wrong elements. Every entry point must agree with what it
+returns for a contiguous copy of the same values.
+"""
+
+import numpy as np
+import pytest
+
+from coreforecast.differences import diff, num_diffs, num_seas_diffs
+from coreforecast.expanding import (
+    expanding_max,
+    expanding_mean,
+    expanding_min,
+    expanding_quantile,
+    expanding_std,
+)
+from coreforecast.exponentially_weighted import exponentially_weighted_mean
+from coreforecast.grouped_array import GroupedArray
+from coreforecast.rolling import (
+    rolling_max,
+    rolling_mean,
+    rolling_min,
+    rolling_quantile,
+    rolling_std,
+    seasonal_rolling_max,
+    seasonal_rolling_mean,
+    seasonal_rolling_min,
+    seasonal_rolling_quantile,
+    seasonal_rolling_std,
+)
+from coreforecast.scalers import boxcox, boxcox_lambda, inv_boxcox
+from coreforecast.seasonal import find_season_length
+
+free_functions = [
+    ("rolling_mean", lambda x: rolling_mean(x, 3, 1)),
+    ("rolling_std", lambda x: rolling_std(x, 3, 2)),
+    ("rolling_min", lambda x: rolling_min(x, 3, 1)),
+    ("rolling_max", lambda x: rolling_max(x, 3, 1)),
+    ("rolling_quantile", lambda x: rolling_quantile(x, 0.5, 3, 1)),
+    ("seasonal_rolling_mean", lambda x: seasonal_rolling_mean(x, 2, 2, 1)),
+    ("seasonal_rolling_std", lambda x: seasonal_rolling_std(x, 2, 2, 2)),
+    ("seasonal_rolling_min", lambda x: seasonal_rolling_min(x, 2, 2, 1)),
+    ("seasonal_rolling_max", lambda x: seasonal_rolling_max(x, 2, 2, 1)),
+    ("seasonal_rolling_quantile", lambda x: seasonal_rolling_quantile(x, 0.5, 2, 2, 1)),
+    ("expanding_mean", expanding_mean),
+    ("expanding_std", expanding_std),
+    ("expanding_min", expanding_min),
+    ("expanding_max", expanding_max),
+    ("expanding_quantile", lambda x: expanding_quantile(x, 0.5)),
+    ("ewm_mean", lambda x: exponentially_weighted_mean(x, 0.5)),
+    ("diff", lambda x: diff(x, 1)),
+    ("num_diffs", lambda x: num_diffs(x, 1)),
+    ("num_seas_diffs", lambda x: num_seas_diffs(x, 2, 1)),
+    ("find_season_length", lambda x: find_season_length(x, 4)),
+    ("boxcox_lambda_loglik", lambda x: boxcox_lambda(x, method="loglik")),
+    ("boxcox_lambda_guerrero", lambda x: boxcox_lambda(x, method="guerrero", season_length=2)),
+    ("boxcox", lambda x: boxcox(x, 0.5)),
+    ("inv_boxcox", lambda x: inv_boxcox(x, 0.5)),
+]
+
+
+@pytest.fixture
+def buffer(rng):
+    return rng.uniform(low=1.0, high=20.0, size=60)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize(
+    "name,fn", free_functions, ids=[f[0] for f in free_functions]
+)
+def test_free_functions_match_a_contiguous_copy(name, fn, buffer, dtype):
+    # every other element of a larger buffer, so reading it as if it were
+    # contiguous picks up the wrong half. Slice after the cast: astype would
+    # return a contiguous copy.
+    view = buffer.astype(dtype)[::2]
+    assert not view.flags["C_CONTIGUOUS"]
+    strided, contiguous = fn(view), fn(np.ascontiguousarray(view))
+    # bit-identical, not merely close: the same values are being read
+    np.testing.assert_array_equal(strided, contiguous)
+    # putting c_style on the parameter instead of ensuring inside would make a
+    # strided float64 array fall through to the float32 overload
+    if isinstance(contiguous, np.ndarray):
+        assert strided.dtype == contiguous.dtype == dtype
+
+
+grouped_operations = [
+    ("rolling_mean", lambda ga: ga._rolling_mean(0, 3, 1)),
+    ("expanding_std", lambda ga: ga._expanding_std(0)[0]),
+    ("minmax_stats", lambda ga: ga._minmax_stats()),
+    ("diff", lambda ga: ga._diff(1)),
+    ("tail", lambda ga: ga._tail(2)),
+]
+
+
+@pytest.mark.parametrize(
+    "name,op", grouped_operations, ids=[o[0] for o in grouped_operations]
+)
+def test_grouped_array_accepts_strided_data(name, op, rng):
+    full = rng.uniform(low=1.0, high=20.0, size=48)
+    view = full[::2]
+    indptr = np.array([0, 8, 16, 24], dtype=np.int32)
+    np.testing.assert_allclose(
+        op(GroupedArray(view, indptr)),
+        op(GroupedArray(np.ascontiguousarray(view), indptr)),
+        equal_nan=True,
+    )
+
+
+def test_grouped_array_accepts_a_strided_indptr():
+    data = np.arange(12, dtype=np.float64)
+    # [0, 4, 8, 12] taken as every other element of a larger array
+    indptr = np.arange(0, 14, 2, dtype=np.int64)[::2]
+    assert not indptr.flags["C_CONTIGUOUS"]
+    ga = GroupedArray(data, indptr)
+    np.testing.assert_array_equal(np.asarray(ga.indptr), [0, 4, 8, 12])
+    assert len(ga) == 3
+
+
+def test_take_and_with_data_accept_strided_input():
+    data = np.arange(12, dtype=np.float64)
+    ga = GroupedArray(data, np.array([0, 4, 8, 12], dtype=np.int32))
+    replacement = np.arange(24, dtype=np.float64)[::2]
+    np.testing.assert_array_equal(
+        ga._with_data(replacement).data, np.ascontiguousarray(replacement)
+    )
+    indices = np.array([0, 9, 2, 9], dtype=np.int32)[::2]
+    np.testing.assert_array_equal(ga._take(indices), ga._take(np.array([0, 2], dtype=np.int32)))

--- a/tests/test_dtype_coercion.py
+++ b/tests/test_dtype_coercion.py
@@ -1,0 +1,79 @@
+"""How the input dtype is chosen.
+
+An explicit float dtype is always honoured. Anything else -- integers, lists,
+Series -- carries no dtype the caller asked for, so it widens to float64
+instead of silently losing precision in float32.
+"""
+
+import numpy as np
+import pytest
+
+from coreforecast.differences import diff
+from coreforecast.expanding import expanding_mean
+from coreforecast.exponentially_weighted import exponentially_weighted_mean
+from coreforecast.grouped_array import GroupedArray
+from coreforecast.rolling import rolling_mean, seasonal_rolling_mean
+from coreforecast.scalers import boxcox, inv_boxcox
+
+free_functions = [
+    ("rolling_mean", lambda x: rolling_mean(x, 2, 1)),
+    ("seasonal_rolling_mean", lambda x: seasonal_rolling_mean(x, 2, 2, 1)),
+    ("expanding_mean", lambda x: expanding_mean(x)),
+    ("exponentially_weighted_mean", lambda x: exponentially_weighted_mean(x, 0.5)),
+    ("diff", lambda x: diff(x, 1)),
+    ("boxcox", lambda x: boxcox(x, 0.5)),
+    ("inv_boxcox", lambda x: inv_boxcox(x, 0.5)),
+]
+
+values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize(
+    "name,fn", free_functions, ids=[f[0] for f in free_functions]
+)
+def test_an_explicit_float_dtype_is_preserved(name, fn, dtype):
+    # these match an overload exactly, so no conversion happens at all
+    assert fn(np.array(values, dtype=dtype)).dtype == dtype
+
+
+@pytest.mark.parametrize(
+    "x",
+    [np.array(values, dtype=np.int64), np.array(values, dtype=np.int32), values],
+    ids=["int64", "int32", "list"],
+)
+@pytest.mark.parametrize(
+    "name,fn", free_functions, ids=[f[0] for f in free_functions]
+)
+def test_input_without_a_float_dtype_widens_to_float64(name, fn, x):
+    # pybind's conversion pass takes the first registered overload, so this is
+    # decided by the order of the init_* calls
+    assert fn(x).dtype == np.float64
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_grouped_array_preserves_an_explicit_float_dtype(dtype):
+    ga = GroupedArray(np.array(values, dtype=dtype), np.array([0, 3, 6]))
+    assert np.asarray(ga.data).dtype == dtype
+
+
+@pytest.mark.parametrize(
+    "x",
+    [np.array(values, dtype=np.int64), np.array(values, dtype=np.int32)],
+    ids=["int64", "int32"],
+)
+def test_grouped_array_widens_like_the_free_functions(x):
+    # the factory casts explicitly rather than going through overload
+    # resolution, so it has to make the same choice on its own
+    ga = GroupedArray(x, np.array([0, 3, 6]))
+    assert np.asarray(ga.data).dtype == np.float64
+
+
+def test_integers_beyond_float32_precision_survive():
+    # 2**24 + 1 is the first integer float32 cannot represent; these used to
+    # come back as [16777216., 16777220., 16777220.]
+    x = np.array([16777217, 16777219, 16777221])
+    np.testing.assert_array_equal(rolling_mean(x, 1, 1), x.astype(np.float64))
+    np.testing.assert_array_equal(
+        np.asarray(GroupedArray(x, np.array([0, 3])).data), x.astype(np.float64)
+    )

--- a/tests/test_nan_contract.py
+++ b/tests/test_nan_contract.py
@@ -1,0 +1,130 @@
+"""The two supported NaN paths.
+
+skipna=False assumes NaNs form a leading run only; skipna=True ignores them
+wherever they are. Both must behave the same through the free functions and
+through GroupedArray.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from coreforecast.expanding import (
+    expanding_max,
+    expanding_mean,
+    expanding_min,
+    expanding_quantile,
+    expanding_std,
+)
+from coreforecast.exponentially_weighted import exponentially_weighted_mean
+from coreforecast.grouped_array import GroupedArray
+from coreforecast.rolling import (
+    rolling_max,
+    rolling_mean,
+    rolling_min,
+    rolling_quantile,
+    rolling_std,
+    seasonal_rolling_max,
+    seasonal_rolling_mean,
+    seasonal_rolling_min,
+    seasonal_rolling_quantile,
+    seasonal_rolling_std,
+)
+
+window_size = 3
+min_samples = 2
+season_length = 2
+
+# (name, free function, equivalent GroupedArray call)
+equivalences = [
+    ("rolling_mean", lambda x: rolling_mean(x, window_size, min_samples),
+     lambda ga: ga._rolling_mean(0, window_size, min_samples)),
+    ("rolling_std", lambda x: rolling_std(x, window_size, min_samples),
+     lambda ga: ga._rolling_std(0, window_size, min_samples)),
+    ("rolling_min", lambda x: rolling_min(x, window_size, min_samples),
+     lambda ga: ga._rolling_min(0, window_size, min_samples)),
+    ("rolling_max", lambda x: rolling_max(x, window_size, min_samples),
+     lambda ga: ga._rolling_max(0, window_size, min_samples)),
+    ("rolling_quantile", lambda x: rolling_quantile(x, 0.5, window_size, min_samples),
+     lambda ga: ga._rolling_quantile(0, 0.5, window_size, min_samples)),
+    ("seasonal_rolling_mean",
+     lambda x: seasonal_rolling_mean(x, season_length, window_size, min_samples),
+     lambda ga: ga._seasonal_rolling_mean(0, season_length, window_size, min_samples)),
+    ("seasonal_rolling_std",
+     lambda x: seasonal_rolling_std(x, season_length, window_size, min_samples),
+     lambda ga: ga._seasonal_rolling_std(0, season_length, window_size, min_samples)),
+    ("seasonal_rolling_min",
+     lambda x: seasonal_rolling_min(x, season_length, window_size, min_samples),
+     lambda ga: ga._seasonal_rolling_min(0, season_length, window_size, min_samples)),
+    ("seasonal_rolling_max",
+     lambda x: seasonal_rolling_max(x, season_length, window_size, min_samples),
+     lambda ga: ga._seasonal_rolling_max(0, season_length, window_size, min_samples)),
+    ("seasonal_rolling_quantile",
+     lambda x: seasonal_rolling_quantile(x, 0.5, season_length, window_size, min_samples),
+     lambda ga: ga._seasonal_rolling_quantile(0, 0.5, season_length, window_size, min_samples)),
+    ("expanding_mean", expanding_mean, lambda ga: ga._expanding_mean(0)[0]),
+    ("expanding_std", expanding_std, lambda ga: ga._expanding_std(0)[0]),
+    ("expanding_min", expanding_min, lambda ga: ga._expanding_min(0)),
+    ("expanding_max", expanding_max, lambda ga: ga._expanding_max(0)),
+    ("expanding_quantile", lambda x: expanding_quantile(x, 0.5),
+     lambda ga: ga._expanding_quantile(0, 0.5)),
+    ("ewm_mean", lambda x: exponentially_weighted_mean(x, 0.5),
+     lambda ga: ga._exponentially_weighted_mean(0, 0.5)),
+]
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("n_leading", [0, 1, 3])
+@pytest.mark.parametrize("name,free_fn,ga_fn", equivalences, ids=[e[0] for e in equivalences])
+def test_leading_nans_match_grouped_array(name, free_fn, ga_fn, n_leading, dtype):
+    x = np.concatenate(
+        [np.full(n_leading, np.nan), np.arange(1, 9)]
+    ).astype(dtype)
+    ga = GroupedArray(x, np.array([0, x.size], dtype=np.int32))
+    np.testing.assert_allclose(free_fn(x), ga_fn(ga), equal_nan=True, rtol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_leading_nans_are_preserved_and_the_rest_is_computed(dtype):
+    x = np.array([np.nan, np.nan, 1.0, 2.0, 3.0, 4.0, 5.0], dtype=dtype)
+    res = rolling_mean(x, window_size=3, min_samples=1)
+    assert np.isnan(res[:2]).all()
+    np.testing.assert_allclose(res[2:], [1.0, 1.5, 2.0, 3.0, 4.0], rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "fn", [rolling_mean, rolling_min, rolling_max, expanding_mean, expanding_min]
+)
+def test_degenerate_inputs(fn):
+    kwargs = {} if fn.__name__.startswith("expanding") else {"window_size": 3}
+    np.testing.assert_array_equal(fn(np.array([]), **kwargs), np.array([]))
+    assert np.isnan(fn(np.full(4, np.nan), **kwargs)).all()
+
+
+def test_skipna_min_max_expire_stale_front_on_a_nan_step():
+    # regression: the monotonic deque's front expires once per *step*, so it must
+    # be checked on NaN steps too, otherwise an out-of-window entry is returned
+    x = np.array([1.0, 2.0, 3.0, np.nan, 5.0, 6.0, 7.0])
+    # index 3's window is [2, 3, nan]; position 0 has left it
+    np.testing.assert_allclose(
+        rolling_min(x, 3, 1, skipna=True), [1.0, 1.0, 1.0, 2.0, 3.0, 5.0, 5.0]
+    )
+    np.testing.assert_allclose(
+        rolling_max(x, 3, 1, skipna=True), [1.0, 2.0, 3.0, 3.0, 5.0, 6.0, 7.0]
+    )
+
+
+@pytest.mark.parametrize("stat", ["min", "max"])
+def test_skipna_min_max_match_pandas_with_scattered_nans(stat, rng):
+    # min_samples=1 is where coreforecast's positional min_samples and pandas'
+    # observation-based min_periods agree, so pandas is a valid oracle there
+    fn = {"min": rolling_min, "max": rolling_max}[stat]
+    for _ in range(200):
+        n = int(rng.integers(2, 30))
+        w = int(rng.integers(1, 10))
+        x = rng.normal(size=n)
+        x[rng.random(n) < 0.4] = np.nan
+        expected = getattr(pd.Series(x).rolling(w, min_periods=1), stat)().to_numpy()
+        np.testing.assert_allclose(
+            fn(x, w, 1, skipna=True), expected, equal_nan=True
+        )

--- a/tests/test_nan_contract.py
+++ b/tests/test_nan_contract.py
@@ -151,11 +151,10 @@ def test_zero_min_samples_is_rejected(fn):
 
 
 @pytest.mark.parametrize("fn", rolling_fns, ids=lambda f: f.__name__)
-def test_negative_counts_are_rejected_by_the_signature(fn):
-    # the bound parameters are unsigned, so pybind refuses these outright
-    with pytest.raises(TypeError):
+def test_negative_counts_are_rejected(fn):
+    with pytest.raises(ValueError, match="window_size must be greater than 0"):
         fn(np.arange(5.0), -3, 1)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError, match="min_samples must be greater than 0"):
         fn(np.arange(5.0), 3, -1)
 
 
@@ -165,10 +164,21 @@ def test_zero_season_length_is_rejected():
         seasonal_rolling_mean(np.arange(5.0), 0, 2, 1)
 
 
-def test_negative_lag_is_rejected_by_the_signature():
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda ga, lag: ga._lag(lag),
+        lambda ga, lag: ga._rolling_mean(lag, 2, 1),
+        lambda ga, lag: ga._rolling_mean_update(lag, 2, 1),
+        lambda ga, lag: ga._expanding_std(lag),
+    ],
+    ids=["lag", "transform", "reduce", "transform_and_reduce"],
+)
+def test_negative_lag_is_rejected(call):
+    # a negative lag makes the transform write before the start of the output
     ga = GroupedArray(np.arange(10.0), np.array([0, 5, 10], dtype=np.int32))
-    with pytest.raises(TypeError):
-        ga._rolling_mean(-3, 2, 1)
+    with pytest.raises(ValueError, match="lag must be non-negative"):
+        call(ga, -3)
 
 
 def test_seasonal_nan_only_latches_within_its_own_season():

--- a/tests/test_nan_contract.py
+++ b/tests/test_nan_contract.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from coreforecast.differences import diff
 from coreforecast.expanding import (
-    expanding_quantile,
     expanding_max,
     expanding_mean,
     expanding_min,
@@ -20,7 +20,6 @@ from coreforecast.expanding import (
 from coreforecast.exponentially_weighted import exponentially_weighted_mean
 from coreforecast.grouped_array import GroupedArray
 from coreforecast.rolling import (
-    seasonal_rolling_quantile,
     rolling_max,
     rolling_mean,
     rolling_min,
@@ -179,6 +178,49 @@ def test_negative_lag_is_rejected(call):
     ga = GroupedArray(np.arange(10.0), np.array([0, 5, 10], dtype=np.int32))
     with pytest.raises(ValueError, match="lag must be non-negative"):
         call(ga, -3)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda ga, d: diff(np.arange(10.0), d),
+        lambda ga, d: ga._diff(d),
+        lambda ga, d: ga._diffs(np.array([d, 1], dtype=np.int32)),
+    ],
+    ids=["free_fn", "grouped", "grouped_variable"],
+)
+def test_negative_d_is_rejected(call):
+    # the difference loop starts at d, so a negative one reads and writes one
+    # element before both buffers
+    ga = GroupedArray(np.arange(10.0), np.array([0, 5, 10], dtype=np.int32))
+    with pytest.raises(ValueError, match="d must be non-negative"):
+        call(ga, -1)
+
+
+def test_zero_d_is_a_copy():
+    np.testing.assert_array_equal(diff(np.arange(5.0), 0), np.arange(5.0))
+
+
+@pytest.mark.parametrize(
+    "call",
+    [lambda ga: ga._expanding_mean(0), lambda ga: ga._expanding_std(0)],
+    ids=["expanding_mean", "expanding_std"],
+)
+@pytest.mark.parametrize(
+    "data,indptr",
+    [
+        ([np.nan, np.nan, 1.0, 2.0, 3.0, 4.0], [0, 2, 6]),
+        ([1.0, 2.0, 3.0, 4.0], [0, 0, 4]),
+    ],
+    ids=["all_nan_group", "empty_group"],
+)
+def test_skipped_groups_get_nan_stats(call, data, indptr):
+    # the kernel never runs for these groups, so their stats row used to be
+    # left at whatever the freshly allocated buffer happened to hold
+    ga = GroupedArray(np.array(data), np.array(indptr, dtype=np.int32))
+    stats = np.asarray(call(ga)[1])
+    assert np.isnan(stats[0]).all()
+    assert np.isfinite(stats[1]).all()
 
 
 def test_seasonal_nan_only_latches_within_its_own_season():

--- a/tests/test_nan_contract.py
+++ b/tests/test_nan_contract.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from coreforecast.expanding import (
+    expanding_quantile,
     expanding_max,
     expanding_mean,
     expanding_min,
@@ -19,6 +20,7 @@ from coreforecast.expanding import (
 from coreforecast.exponentially_weighted import exponentially_weighted_mean
 from coreforecast.grouped_array import GroupedArray
 from coreforecast.rolling import (
+    seasonal_rolling_quantile,
     rolling_max,
     rolling_mean,
     rolling_min,
@@ -128,3 +130,81 @@ def test_skipna_min_max_match_pandas_with_scattered_nans(stat, rng):
         np.testing.assert_allclose(
             fn(x, w, 1, skipna=True), expected, equal_nan=True
         )
+
+
+rolling_fns = [rolling_mean, rolling_std, rolling_min, rolling_max]
+
+
+@pytest.mark.parametrize("fn", rolling_fns, ids=lambda f: f.__name__)
+def test_zero_window_size_is_rejected(fn):
+    # zero made the growing loop start at -1 and read and write one element
+    # before the buffers
+    with pytest.raises(ValueError, match="window_size must be greater than 0"):
+        fn(np.arange(5.0), 0, 1)
+
+
+@pytest.mark.parametrize("fn", rolling_fns, ids=lambda f: f.__name__)
+def test_zero_min_samples_is_rejected(fn):
+    # same out-of-bounds start, reached through min_samples instead
+    with pytest.raises(ValueError, match="min_samples must be greater than 0"):
+        fn(np.arange(5.0), 3, 0)
+
+
+@pytest.mark.parametrize("fn", rolling_fns, ids=lambda f: f.__name__)
+def test_negative_counts_are_rejected_by_the_signature(fn):
+    # the bound parameters are unsigned, so pybind refuses these outright
+    with pytest.raises(TypeError):
+        fn(np.arange(5.0), -3, 1)
+    with pytest.raises(TypeError):
+        fn(np.arange(5.0), 3, -1)
+
+
+def test_zero_season_length_is_rejected():
+    # season_length divides, so zero used to raise SIGFPE and kill the process
+    with pytest.raises(ValueError, match="season_length must be greater than 0"):
+        seasonal_rolling_mean(np.arange(5.0), 0, 2, 1)
+
+
+def test_negative_lag_is_rejected_by_the_signature():
+    ga = GroupedArray(np.arange(10.0), np.array([0, 5, 10], dtype=np.int32))
+    with pytest.raises(TypeError):
+        ga._rolling_mean(-3, 2, 1)
+
+
+def test_seasonal_nan_only_latches_within_its_own_season():
+    # seasonal ops de-interleave, so a NaN poisons its own subseries only
+    x = np.array([1.0, 2.0, 3.0, np.nan, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    np.testing.assert_allclose(
+        seasonal_rolling_mean(x, 2, 2, 1),
+        [1.0, 2.0, 2.0, np.nan, 4.0, np.nan, 6.0, np.nan, 8.0, np.nan],
+    )
+
+
+quantile_entry_points = [
+    ("rolling_quantile", lambda x, ga, p: rolling_quantile(x, p, 3, 1)),
+    ("seasonal_rolling_quantile", lambda x, ga, p: seasonal_rolling_quantile(x, p, 2, 2, 1)),
+    ("expanding_quantile", lambda x, ga, p: expanding_quantile(x, p)),
+    ("ga_rolling_quantile", lambda x, ga, p: ga._rolling_quantile(0, p, 3, 1)),
+    ("ga_rolling_quantile_update", lambda x, ga, p: ga._rolling_quantile_update(0, p, 3, 1)),
+    ("ga_expanding_quantile", lambda x, ga, p: ga._expanding_quantile(0, p)),
+    ("ga_expanding_quantile_update", lambda x, ga, p: ga._expanding_quantile_update(0, p)),
+    ("ga_seasonal_rolling_quantile", lambda x, ga, p: ga._seasonal_rolling_quantile(0, p, 2, 2, 1)),
+]
+
+
+@pytest.mark.parametrize("p", [-2.0, 1.5, np.nan])
+@pytest.mark.parametrize(
+    "name,fn", quantile_entry_points, ids=[q[0] for q in quantile_entry_points]
+)
+def test_quantile_level_outside_the_unit_interval_is_rejected(name, fn, p):
+    # p indexes into the sorted window, so an out-of-range value read past the
+    # end of the buffer; expanding_quantile_update returned uninitialised memory
+    x = np.arange(20.0)
+    ga = GroupedArray(x, np.array([0, 10, 20], dtype=np.int32))
+    with pytest.raises(ValueError, match="p must be between 0 and 1"):
+        fn(x, ga, p)
+
+
+@pytest.mark.parametrize("p", [0.0, 0.5, 1.0])
+def test_quantile_level_bounds_are_inclusive(p):
+    assert np.isfinite(rolling_quantile(np.arange(20.0), p, 3, 1)).any()

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -141,6 +141,17 @@ class TestIndptrValidation:
         assert len(ga) == 2
         np.testing.assert_array_equal(np.asarray(ga.indptr), [0, 3, 6])
 
+    def test_take_rejects_out_of_range_group_indices(self):
+        # take indexes indptr directly, so an out of range group reads past its
+        # end and slices data with whatever it finds there
+        ga = GroupedArray(np.arange(6.0), np.array([0, 3, 6], dtype=np.int32))
+        for idx in (2, 5, -1):
+            with pytest.raises(IndexError, match="Index out of range"):
+                ga._take(np.array([idx], dtype=np.int32))
+        np.testing.assert_array_equal(
+            ga._take(np.array([1, 0], dtype=np.int32)), [3.0, 4.0, 5.0, 0.0, 1.0, 2.0]
+        )
+
     @pytest.mark.parametrize(
         "cls", [_GroupedArrayFloat32, _GroupedArrayFloat64], ids=["f32", "f64"]
     )

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -66,8 +66,8 @@ def test_degenerate_thread_counts(num_threads):
 
 @pytest.mark.parametrize("num_threads", [1, 4])
 def test_worker_exception_surfaces_as_python_exception(grouped, num_threads):
-    # a negative window makes the kernel ask for an impossible allocation; the
-    # throw happens inside the worker and used to reach std::terminate
+    # a negative window is rejected by the kernel, so the throw happens inside
+    # the worker and used to reach std::terminate
     data, indptr = grouped
     ga = GroupedArray(data, indptr, num_threads=num_threads)
     with pytest.raises(Exception):

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,100 @@
+"""The multi-threaded GroupedArray path.
+
+Groups are split across threads, so results must not depend on how many are
+used, and a failure inside a worker must surface as a Python exception rather
+than taking the interpreter down with it.
+"""
+
+import numpy as np
+import pytest
+
+from coreforecast.grouped_array import GroupedArray
+
+thread_counts = [2, 3, 8]
+
+operations = [
+    ("rolling_mean", lambda ga: ga._rolling_mean(1, 5, 2)),
+    ("rolling_std", lambda ga: ga._rolling_std(1, 5, 2)),
+    ("rolling_min", lambda ga: ga._rolling_min(1, 5, 2)),
+    ("rolling_max", lambda ga: ga._rolling_max(1, 5, 2)),
+    ("rolling_quantile", lambda ga: ga._rolling_quantile(1, 0.5, 5, 2)),
+    ("seasonal_rolling_mean", lambda ga: ga._seasonal_rolling_mean(1, 7, 3, 2)),
+    ("expanding_mean", lambda ga: ga._expanding_mean(1)[0]),
+    ("expanding_std", lambda ga: ga._expanding_std(1)[0]),
+    ("ewm_mean", lambda ga: ga._exponentially_weighted_mean(1, 0.8)),
+    ("minmax_stats", lambda ga: ga._minmax_stats()),
+    ("standard_stats", lambda ga: ga._standard_stats()),
+    ("robust_iqr_stats", lambda ga: ga._robust_iqr_stats()),
+    ("robust_mad_stats", lambda ga: ga._robust_mad_stats()),
+    ("num_diffs", lambda ga: ga._num_diffs(2)),
+    ("diff", lambda ga: ga._diff(1)),
+    ("tail", lambda ga: ga._tail(3)),
+]
+
+
+@pytest.fixture
+def grouped(rng):
+    lengths = rng.integers(low=40, high=90, size=50)
+    indptr = np.append(0, lengths.cumsum()).astype(np.int32)
+    return rng.normal(size=indptr[-1]), indptr
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("num_threads", thread_counts)
+@pytest.mark.parametrize("name,op", operations, ids=[o[0] for o in operations])
+def test_results_do_not_depend_on_thread_count(name, op, num_threads, grouped, dtype):
+    data, indptr = grouped
+    data = data.astype(dtype)
+    serial = op(GroupedArray(data, indptr, num_threads=1))
+    parallel = op(GroupedArray(data, indptr, num_threads=num_threads))
+    np.testing.assert_array_equal(serial, parallel)
+
+
+@pytest.mark.parametrize("num_threads", [-5, 0, 1, 64])
+def test_degenerate_thread_counts(num_threads):
+    # more threads than groups used to spawn workers with empty ranges
+    data = np.arange(6, dtype=np.float64)
+    indptr = np.array([0, 3, 6], dtype=np.int32)
+    ga = GroupedArray(data, indptr, num_threads=num_threads)
+    # min_samples=1, so each group's first element is its own mean
+    np.testing.assert_allclose(ga._rolling_mean(0, 2, 1), [0.0, 0.5, 1.5, 3.0, 3.5, 4.5])
+
+
+@pytest.mark.parametrize("num_threads", [1, 4])
+def test_worker_exception_surfaces_as_python_exception(grouped, num_threads):
+    # a negative window makes the kernel ask for an impossible allocation; the
+    # throw happens inside the worker and used to reach std::terminate
+    data, indptr = grouped
+    ga = GroupedArray(data, indptr, num_threads=num_threads)
+    with pytest.raises(Exception):
+        ga._rolling_mean_update(0, -1, -1)
+    # the object is still usable afterwards
+    assert np.isfinite(ga._rolling_mean(0, 3, 1)).any()
+
+
+def test_num_threads_is_mutable_at_runtime(grouped):
+    data, indptr = grouped
+    ga = GroupedArray(data, indptr, num_threads=1)
+    expected = ga._rolling_mean(1, 5, 2)
+    ga.num_threads = 4
+    np.testing.assert_array_equal(ga._rolling_mean(1, 5, 2), expected)
+
+
+class TestIndptrValidation:
+    def test_rejects_values_beyond_the_32_bit_range(self):
+        with pytest.raises(ValueError, match="32-bit"):
+            GroupedArray(np.zeros(3), np.array([0, 1, 2**31 + 5], dtype=np.int64))
+
+    def test_rejects_a_value_that_would_wrap_onto_the_data_size(self):
+        # 2**32 + 3 truncates to exactly 3, so the size check alone would pass it
+        with pytest.raises(ValueError, match="32-bit"):
+            GroupedArray(np.zeros(3), np.array([0, 1, 2**32 + 3], dtype=np.int64))
+
+    def test_rejects_a_mismatched_last_element(self):
+        with pytest.raises(ValueError, match="Last element"):
+            GroupedArray(np.zeros(3), np.array([0, 1, 5], dtype=np.int64))
+
+    @pytest.mark.parametrize("dtype", [np.int32, np.int64])
+    def test_accepts_valid_integer_indptr(self, dtype):
+        ga = GroupedArray(np.zeros(3), np.array([0, 1, 3], dtype=dtype))
+        assert len(ga) == 2

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -94,7 +94,38 @@ class TestIndptrValidation:
         with pytest.raises(ValueError, match="Last element"):
             GroupedArray(np.zeros(3), np.array([0, 1, 5], dtype=np.int64))
 
+    @pytest.mark.parametrize(
+        "indptr",
+        [
+            [0, 2**31 + 100, 3],  # wraps to a large negative offset
+            [0, 2**32, 3],  # wraps to zero
+            [0, -1, 3],  # negative outright
+        ],
+    )
+    def test_rejects_out_of_range_intermediate_entries(self, indptr):
+        # every entry is an offset into data, so checking only the last one
+        # leaves the rest free to wrap during the int32 cast
+        with pytest.raises(ValueError, match="non-negative"):
+            GroupedArray(np.zeros(3), np.array(indptr, dtype=np.int64))
+
+    @pytest.mark.parametrize(
+        "data_size,indptr",
+        [
+            (1, [0, 3, 1]),  # decreasing, yet last still equals len(data)
+            (6, [0, 5, 2, 6]),
+        ],
+    )
+    def test_rejects_non_monotonic_indptr(self, data_size, indptr):
+        # a decreasing entry makes a group span past the end of its own data
+        with pytest.raises(ValueError, match="non-decreasing"):
+            GroupedArray(np.zeros(data_size), np.array(indptr, dtype=np.int64))
+
     @pytest.mark.parametrize("dtype", [np.int32, np.int64])
     def test_accepts_valid_integer_indptr(self, dtype):
         ga = GroupedArray(np.zeros(3), np.array([0, 1, 3], dtype=dtype))
         assert len(ga) == 2
+
+    def test_accepts_empty_groups(self):
+        # equal consecutive entries are a legitimate empty group
+        ga = GroupedArray(np.zeros(6), np.array([0, 3, 3, 6], dtype=np.int64))
+        assert len(ga) == 3

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -162,6 +162,10 @@ class TestIndptrValidation:
             ga._tails(np.array([0, -5, 2**30], dtype=np.int32))
         with pytest.raises(ValueError, match="non-decreasing"):
             ga._tails(np.array([0, 2, 1], dtype=np.int32))
+        # the output is sized from the last offset, so starting past zero left
+        # its first elements as uninitialized heap
+        with pytest.raises(ValueError, match="First element"):
+            ga._tails(np.array([2, 3, 4], dtype=np.int32))
         np.testing.assert_array_equal(
             ga._tails(np.array([0, 1, 2], dtype=np.int32)), [2.0, 5.0]
         )

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -99,17 +99,17 @@ class TestIndptrValidation:
             GroupedArray(np.zeros(3), np.array([0, 1, 5], dtype=np.int64))
 
     @pytest.mark.parametrize(
-        "indptr",
+        "indptr,match",
         [
-            [0, 2**31 + 100, 3],  # wraps to a large negative offset
-            [0, 2**32, 3],  # wraps to zero
-            [0, -1, 3],  # negative outright
+            ([0, 2**31 + 100, 3], "32-bit"),  # wraps to a large negative offset
+            ([0, 2**32, 3], "32-bit"),  # wraps to zero
+            ([0, -1, 3], "non-negative"),  # negative outright
         ],
     )
-    def test_rejects_out_of_range_intermediate_entries(self, indptr):
+    def test_rejects_out_of_range_intermediate_entries(self, indptr, match):
         # every entry is an offset into data, so checking only the last one
         # leaves the rest free to wrap during the int32 cast
-        with pytest.raises(ValueError, match="non-negative"):
+        with pytest.raises(ValueError, match=match):
             GroupedArray(np.zeros(3), np.array(indptr, dtype=np.int64))
 
     @pytest.mark.parametrize(
@@ -152,14 +152,63 @@ class TestIndptrValidation:
             ga._take(np.array([1, 0], dtype=np.int32)), [3.0, 4.0, 5.0, 0.0, 1.0, 2.0]
         )
 
+    def test_tails_validates_its_output_indptr(self):
+        # out_indptr both sizes and indexes the output buffer but was taken on
+        # trust, so bogus offsets segfaulted
+        ga = GroupedArray(np.arange(6.0), np.array([0, 3, 6], dtype=np.int32))
+        with pytest.raises(ValueError, match="one element per group plus one"):
+            ga._tails(np.array([0, 2], dtype=np.int32))
+        with pytest.raises(ValueError, match="non-negative"):
+            ga._tails(np.array([0, -5, 2**30], dtype=np.int32))
+        with pytest.raises(ValueError, match="non-decreasing"):
+            ga._tails(np.array([0, 2, 1], dtype=np.int32))
+        np.testing.assert_array_equal(
+            ga._tails(np.array([0, 1, 2], dtype=np.int32)), [2.0, 5.0]
+        )
+
     @pytest.mark.parametrize(
         "cls", [_GroupedArrayFloat32, _GroupedArrayFloat64], ids=["f32", "f64"]
     )
     def test_typed_constructors_validate_too(self, cls):
         # these are module attributes, so they must not bypass the checks the
         # GroupedArray factory applies
-        with pytest.raises(ValueError, match="non-negative"):
+        with pytest.raises(ValueError, match="32-bit"):
             cls(np.zeros(3), np.array([0, 1, 2**31 + 5], dtype=np.int64), 1)
         with pytest.raises(ValueError, match="non-decreasing"):
             cls(np.zeros(6), np.array([0, 5, 2, 6], dtype=np.int64), 1)
         assert len(cls(np.zeros(6), [0, 3, 6], 1)) == 2
+
+
+class TestDsValidation:
+    @pytest.fixture
+    def ga(self):
+        return GroupedArray(np.arange(6.0), np.array([0, 3, 6], dtype=np.int32))
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda ga, ds: ga._diffs(ds),
+            lambda ga, ds: ga._inv_diffs(ds, np.arange(2.0)),
+        ],
+        ids=["diffs", "inv_diffs"],
+    )
+    def test_rejects_a_ds_shorter_than_the_group_count(self, ga, call):
+        # ds is indexed once per group, so a short one is read past its end
+        with pytest.raises(ValueError, match="one element per group"):
+            call(ga, np.array([1], dtype=np.int32))
+
+    def test_rejects_tails_that_do_not_match_the_sum_of_ds(self, ga):
+        # the tails array is grouped directly rather than through the factory,
+        # so the last-offset check the factory does has to happen here
+        with pytest.raises(ValueError, match="sum of ds"):
+            ga._inv_diffs(np.array([1, 1], dtype=np.int32), np.arange(1.0))
+
+    def test_rejects_negative_entries(self, ga):
+        with pytest.raises(ValueError, match="d must be non-negative"):
+            ga._inv_diffs(np.array([-1, 1], dtype=np.int32), np.arange(2.0))
+
+    def test_accepts_matching_arguments(self, ga):
+        np.testing.assert_allclose(
+            ga._inv_diffs(np.array([1, 1], dtype=np.int32), np.arange(2.0)),
+            [0.0, 1.0, 3.0, 4.0, 8.0, 13.0],
+        )

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -8,6 +8,10 @@ than taking the interpreter down with it.
 import numpy as np
 import pytest
 
+from coreforecast._lib.grouped_array import (
+    _GroupedArrayFloat32,
+    _GroupedArrayFloat64,
+)
 from coreforecast.grouped_array import GroupedArray
 
 thread_counts = [2, 3, 8]
@@ -129,3 +133,22 @@ class TestIndptrValidation:
         # equal consecutive entries are a legitimate empty group
         ga = GroupedArray(np.zeros(6), np.array([0, 3, 3, 6], dtype=np.int64))
         assert len(ga) == 3
+
+    @pytest.mark.parametrize("indptr", [[0, 3, 6], (0, 3, 6)])
+    def test_accepts_non_ndarray_sequences(self, indptr):
+        # validating in 64 bits must not cost the flexibility of forcecast
+        ga = GroupedArray(np.arange(6.0), indptr, 1)
+        assert len(ga) == 2
+        np.testing.assert_array_equal(np.asarray(ga.indptr), [0, 3, 6])
+
+    @pytest.mark.parametrize(
+        "cls", [_GroupedArrayFloat32, _GroupedArrayFloat64], ids=["f32", "f64"]
+    )
+    def test_typed_constructors_validate_too(self, cls):
+        # these are module attributes, so they must not bypass the checks the
+        # GroupedArray factory applies
+        with pytest.raises(ValueError, match="non-negative"):
+            cls(np.zeros(3), np.array([0, 1, 2**31 + 5], dtype=np.int64), 1)
+        with pytest.raises(ValueError, match="non-decreasing"):
+            cls(np.zeros(6), np.array([0, 5, 2, 6], dtype=np.int64), 1)
+        assert len(cls(np.zeros(6), [0, 3, 6], 1)) == 2

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,131 @@
+"""Arguments that used to reach the kernels and read or write out of bounds.
+
+Every case here was confirmed with AddressSanitizer or UBSan before the checks
+it exercises were added.
+"""
+
+import numpy as np
+import pytest
+
+from coreforecast.differences import num_seas_diffs
+from coreforecast.grouped_array import GroupedArray
+from coreforecast.lag_transforms import ExpandingMean, Lag
+from coreforecast.scalers import LocalBoxCoxScaler, boxcox_lambda
+from coreforecast.seasonal import find_season_length
+
+
+@pytest.fixture
+def ga():
+    return GroupedArray(np.arange(10.0), np.array([0, 5, 10], dtype=np.int32))
+
+
+class TestK:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda ga, k: ga._index_from_end(k),
+            lambda ga, k: ga._head(k),
+            lambda ga, k: ga._tail(k),
+        ],
+        ids=["index_from_end", "head", "tail"],
+    )
+    def test_rejects_a_negative_k(self, ga, call):
+        # k counts back from the end of a group, so -1 read one past it
+        with pytest.raises(ValueError, match="k must be non-negative"):
+            call(ga, -1)
+
+    @pytest.mark.parametrize(
+        "call", [lambda ga: ga._head(0), lambda ga: ga._tail(0)], ids=["head", "tail"]
+    )
+    def test_zero_k_is_empty(self, ga, call):
+        assert call(ga).size == 0
+
+    def test_lag_zero_cannot_update(self, ga):
+        # an update consumes the value that isn't in ga yet, so lag 0 has
+        # nothing to read and used to index one past the group
+        with pytest.raises(ValueError, match="lag must be greater than 0"):
+            Lag(0).update(ga)
+
+    def test_lag_zero_transforms_but_cannot_update(self, ga):
+        tfm = ExpandingMean(0)
+        tfm.transform(ga)  # an un-lagged transform is legitimate
+        with pytest.raises(ValueError, match="lag must be greater than 0"):
+            tfm.update(ga)
+        # the rejected update must not have advanced the counts
+        np.testing.assert_array_equal(tfm.stats_[:, 0], [5.0, 5.0])
+
+
+class TestPeriodsValidation:
+    @pytest.mark.parametrize("size", [1, 200], ids=["undersized", "oversized"])
+    def test_rejects_a_periods_that_is_not_one_per_group(self, ga, size):
+        # the copy loop runs over periods, so an oversized one wrote past the
+        # buffer it fills and an undersized one left the rest uninitialised
+        with pytest.raises(ValueError, match="periods must have one element per group"):
+            ga._num_seas_diffs_periods(1, np.full(size, 2.0))
+
+    def test_matches_the_scalar_season_length_path(self):
+        x = np.tile(np.arange(12.0), 5) + np.arange(60.0)
+        ga = GroupedArray(np.hstack([x, x]), np.array([0, 60, 120], dtype=np.int32))
+        np.testing.assert_array_equal(
+            ga._num_seas_diffs_periods(1, np.full(2, 12.0)), ga._num_seas_diffs(12, 1)
+        )
+
+
+class TestStatsValidation:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda ga, stats: ga._scaler_transform(stats),
+            lambda ga, stats: ga._scaler_inverse_transform(stats),
+            lambda ga, stats: ga._boxcox(stats),
+            lambda ga, stats: ga._inv_boxcox(stats),
+        ],
+        ids=["scaler_transform", "scaler_inverse_transform", "boxcox", "inv_boxcox"],
+    )
+    @pytest.mark.parametrize(
+        "stats",
+        [np.zeros(1), np.zeros(4), np.zeros((1, 2)), np.zeros((3, 2))],
+        ids=["short_1d", "flat_1d", "too_few_groups", "too_many_groups"],
+    )
+    def test_rejects_stats_that_are_not_two_per_group(self, ga, call, stats):
+        # every group reads stats[2 * i] and stats[2 * i + 1], so anything
+        # shorter is read past its end
+        with pytest.raises(ValueError, match=r"stats must have shape"):
+            call(ga, stats)
+
+    def test_accepts_two_stats_per_group(self, ga):
+        stats = np.array([[0.0, 2.0], [0.0, 2.0]])
+        np.testing.assert_allclose(ga._scaler_transform(stats), np.arange(10.0) / 2)
+
+
+class TestSeasonLength:
+    @pytest.mark.parametrize("season_length", [0, -3])
+    def test_guerrero_rejects_a_non_positive_season_length(self, ga, season_length):
+        # n_seasons = n / period, so zero divided by zero and a negative one
+        # sized a vector with a huge value
+        with pytest.raises(ValueError, match="season_length must be greater than 0"):
+            boxcox_lambda(np.arange(1.0, 11.0), "guerrero", season_length)
+        with pytest.raises(ValueError, match="season_length must be greater than 0"):
+            LocalBoxCoxScaler("guerrero", season_length)
+        with pytest.raises(ValueError, match="season_length must be greater than 0"):
+            ga._boxcox_guerrero(season_length, -0.9, 2.0)
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda ga, period: num_seas_diffs(np.arange(1.0, 11.0), period, 1),
+            lambda ga, period: ga._num_seas_diffs(period, 1),
+        ],
+        ids=["free_fn", "grouped"],
+    )
+    def test_num_seas_diffs_rejects_a_negative_season_length(self, ga, call):
+        with pytest.raises(ValueError, match="season_length must be non-negative"):
+            call(ga, -2)
+
+    def test_num_seas_diffs_accepts_zero(self, ga):
+        # find_season_length passes the zero it gets when it finds no seasonality
+        assert num_seas_diffs(np.arange(1.0, 11.0), 0, 1) == 0
+        np.testing.assert_array_equal(ga._num_seas_diffs(0, 1), [0.0, 0.0])
+
+    def test_find_season_length_without_seasonality(self):
+        assert find_season_length(np.arange(1.0, 30.0), 10) == 0


### PR DESCRIPTION
Aligns NaN handling between the free functions and `GroupedArray`, fixes a `skipna=True` rolling min/max bug, hardens the multi-threaded path, validates every numeric and array argument that reaches the kernels, widens unspecified-dtype input to float64, and adds the CI gates that keep all of it from regressing. Several of these were reachable out-of-bounds accesses from ordinary Python calls.

## Behaviour changes

**The free functions ignored the leading-NaN contract.** `GroupedArray` strips the leading NaN run with `FirstNotNaN` before calling any kernel; the free functions handed it the raw buffer, so the same series gave two different answers:

```python
rolling_mean(np.array([np.nan, 1, 2, 3, 4, 5]), 3, 1)  # -> all NaN
ga._rolling_mean(0, 3, 1)                              # -> [nan, 1, 1.5, 2, 3, 4]
```

A `SkipLeadingNaN` helper in `common.h` copies the prefix to the output and hands the kernel the valid tail. Applied to the rolling, seasonal rolling, expanding and exponentially weighted entry points — all seven now agree with `GroupedArray`. It also stops empty and all-NaN inputs from reaching kernels that read `data[0]` unguarded.

One consequence worth calling out because it *reads* like a regression and isn't: with a leading NaN run and `skipna=True`, `rolling_mean([nan]*3 + [1, 2], 4, 4)` goes from `[nan, nan, nan, 1, 1.5]` to all-NaN. pandas gives all-NaN, so the new output is the correct one.

**Rolling min/max returned stale values with `skipna=True`.** `CompAccumulator::Insert` returned early on a NaN before reaching the front-expiry check. That check is a single `if`, not a loop, so it ran once per *valid element* rather than once per *step*, and an entry that should have left the window never did:

```python
rolling_min(np.array([1, 2, 3, np.nan, 5, 6, 7]), 3, 1, skipna=True)
# was  [1, 1, 1, 1, 2, 3, 5]   <- index 3 is 1, but its window is [2, 3, nan]
# now  [1, 1, 1, 2, 3, 5, 5]   <- matches pandas
```

Verified against pandas over 6000 randomised arrays at `min_samples=1`, where coreforecast's positional `min_samples` and pandas' observation-based `min_periods` agree; and against an oracle modelling coreforecast's own semantics over 8000 arrays across all `min_samples`. No mismatches.

**Non-contiguous input gave results for the wrong elements.** The bound parameters take a raw pointer, so a strided view was read as if it were contiguous:

```python
rolling_mean(x[::2], 2, 1)   # returned values for x[0:5]
```

Affected `rolling_*`, `seasonal_rolling_*`, `expanding_*`, `ewm_mean`, `diff`, `num_diffs`, `find_season_length`, `boxcox_lambda`, `boxcox`, `inv_boxcox`, and `GroupedArray` for strided `data`, `indptr`, `_take` and `_with_data`.

Fixed with an `AsContiguous` helper rather than by putting `c_style` on the parameters. `array_t::check_` tests flags as well as dtype, so `c_style` on the parameter makes a strided array match nothing in pybind's no-conversion pass; the conversion pass then picks the first registered overload and silently converts to its dtype. Ensuring contiguity inside the function keeps dtype dispatch intact.

**Input without a float dtype now widens to float64 instead of float32.** Integer arrays, lists and Series carry no dtype the caller asked for, and float32 is lossy from `2**24` on:

```python
rolling_mean(np.array([16777217, 16777219, 16777221]), 1, 1)
# was [16777216., 16777220., 16777220.]
```

For the free functions this follows from the registration order, since pybind's conversion pass takes the first overload registered; an exact dtype match is resolved in the earlier no-conversion pass, so float32 and float64 arrays are unaffected either way. The `GroupedArray` factory casts explicitly rather than going through overload resolution, so it gets the same change directly. This is user-visible: unspecified-dtype input now returns float64 and takes twice the memory. Callers who want float32 pass a float32 array, which was already the only way to be sure of it.

## Input validation

Every one of these was reachable from Python and every one was an out-of-bounds access or worse:

| argument | invalid value | before | now |
| --- | --- | --- | --- |
| `window_size` | `0` | OOB read/write | `ValueError` |
| `min_samples` | `0` | OOB read/write, returned `2.4e-322` | `ValueError` |
| `season_length` | `0` | **SIGFPE, interpreter killed** | `ValueError` |
| `window_size`, `min_samples`, `season_length` | negative | OOB read | `ValueError` |
| `lag`, `d` | negative | OOB read/write | `ValueError` |
| `p` | outside `[0, 1]`, `NaN` | OOB read, returned `1e-322` | `ValueError` |
| `indptr` | negative, `> 2**31`, non-monotonic | OOB read | `ValueError` |
| group index in `_take` | out of range | OOB read | `IndexError` |
| `out_indptr` in `_tails` | negative, non-monotonic, wrong length | **segfault** | `ValueError` |
| `ds` | wrong length, negative entries | OOB read | `ValueError` |
| `k` in `_index_from_end`, `_head`, `_tail` | negative | OOB read | `ValueError` |
| `periods` in `_num_seas_diffs_periods` | wrong length | heap overflow / uninitialised read | `ValueError` |
| `stats`, `lambdas` in the scaler transforms | not `(n_groups, 2)` | OOB read | `ValueError` |
| `season_length` for guerrero | `0`, negative | division by zero (UBSan) | `ValueError` |
| `season_length` in `num_seas_diffs` | negative | opaque STL error | `ValueError` |
| `lag=0` on a lag transform's `update` | — | OOB read | `ValueError` |

Notes on the less obvious ones:

- `indptr` is validated in 64 bits before the cast, since it is force-cast to `int32` during argument conversion: `[0, 1, 2**32 + 3]` truncated to `[0, 1, 3]` and passed the size check. Every entry is checked, not just the last, and the sequence must be non-decreasing — `[0, 3, 1]` over a one-element array passed every other check and then had group 0 cover `data[0:3]`. The `_GroupedArrayFloat32/64` constructors route through the same checks rather than bypassing them, and still accept lists, tuples and Series.
- `k = -1` made `IndexFromEnd` read `data[n]`, one past the group, and it was reachable through `Lag(0).update(ga)` and `ExpandingMean(0).update(ga)`, which both pass `self.lag - 1`. Every lag transform's `update` now goes through a `_update_lag` property that rejects a lag below 1: an update consumes the value that isn't in the array yet, so there is nothing for it to read. `transform` with `lag=0` stays valid — it is a legitimate un-lagged transform.
- `season_length = 0` stays valid for `num_seas_diffs`, because `find_season_length` passes the zero it gets when it finds no seasonality and multiplies the result by it.
- `p` is now checked at all nine quantile bindings rather than only inside the kernel, which never runs when every group is empty or all-NaN.

## Robustness

- **`ForEach` could take down the interpreter.** It and the seven skeletons built on it were marked `noexcept` but can all throw, and anything escaping a `std::thread` body calls `std::terminate` regardless. Each worker now stores its exception and it is rethrown after every thread is joined. The worker count is clamped too — `num_threads` is exposed through `def_readwrite`, so it could be set to 0 or negative at runtime, and a value above the group count spawned threads with empty ranges.

- **The GIL is now released** around the computation. The four scaler stats methods were the only obstacle: they hand-rolled their own `ForEach` loop and called `out.mutable_data()` from inside the workers. They now go through the `ScalerStats` helper that was already defined directly above them and never called.

- **`CompAccumulator`'s ring buffer** used `reserve()` and then wrote through `operator[]`, which is out of bounds. Now `resize()`.

- **Skipped groups kept whatever the buffer held.** An empty or all-NaN group never runs the kernel, so its stats row was left at whatever the freshly allocated buffer happened to contain. Those rows are now written explicitly.

## CI gates

The branch changed no workflow or CMake file, so nothing prevented the next reserve-instead-of-resize from shipping. Two jobs now cover it:

- **`Run tests under ASan and UBSan`** — one Linux job that builds with `-fsanitize=address,undefined -D_GLIBCXX_ASSERTIONS` and runs the suite under it. Non-editable install, and `--no-install-project` / `--no-sync` on the uv commands so the instrumented build is the one actually tested.
- **`Build with -Werror`** — `-Wall -Wextra` now applies to every build, on gcc and on AppleClang. `-Werror` is behind a `COREFORECAST_WERROR` option that defaults to `OFF` and this job turns on, so a new compiler warning about existing code fails one CI job rather than everyone's source install. The third-party include directories are marked `SYSTEM` and the vendored `SkipList.cpp` gets `-w`, so the gate only covers our own code, which is clean today. MSVC is left out until `/W4` on the Eigen and pybind11 headers gets its own pass.

Project code needed three fixes to build clean: two unused parameter names in `CompAccumulator::Update`, an `indptr_t`/`size_t` comparison in `seasonal.h`, and `GroupedArray` moved into an anonymous namespace, since a default-visibility class holding `py::array_t` fields warns under `-fvisibility=hidden`.

## Docs

`skipna=False` keeps its contract — NaNs are assumed to form a leading run only. The docstrings claimed a NaN *"in the window"* makes the result NaN, implying recovery once it slides out; nothing implemented that. The seasonal docstrings needed different wording again, since those ops de-interleave and a NaN only latches within its own season.

The local scalers said an interior NaN with `skipna=False` "may result in NaN statistics". It doesn't for min-max, where the result is whichever value wins an unordered comparison; those docstrings now say that only a leading run is supported on that path and to pass `skipna=True` otherwise.

`CHANGELOG.md` records the three user-visible changes: the NaN contract, the float64 widening, and the new validation errors. The repo had no changelog file before — happy to move this into the release notes instead if that fits the release-drafter flow better.

## Cleanup

The four `*TransformDispatch` wrappers duplicated `rolling::MeanTransform` and friends verbatim, along with 24 explicit template instantiations. Neither was needed: the skipna dispatch is a runtime branch, not `if constexpr`, so `m.def` already instantiates both specializations of every accumulator. `scalers.h`'s four stats functions each repeated a NaN-filtering block and their own body twice; a `WithSkipNA` wrapper collapses them. `scalers.h` and `common.h` also now include `<cmath>` and `<limits>` explicitly.

## Testing

633 tests, up from 201. Four new files:

- `test_nan_contract.py` — leading-NaN equivalence between both entry points, the deque regression, and the scalar argument validation
- `test_threading.py` — serial/parallel equivalence for 16 operations at 1/2/3/8 threads, degenerate thread counts, worker-exception propagation, `indptr` and `ds` validation
- `test_contiguity.py` — every entry point against a contiguous copy of the same values, asserting bit-identical results *and* preserved dtype (a value-only assertion passes under the float32 downcast, which is how it nearly shipped)
- `test_validation.py` — the `k`, `periods`, `stats` and `season_length` entry points, each confirmed with ASan or UBSan before the check was added
- `test_dtype_coercion.py` — the dtype every entry point returns for float32, float64, int and list input

The multi-threaded path previously had two test invocations in the whole suite, neither on a rolling op.

## Performance

Nothing per-element was added to the benchmarked `GroupedArray` path; the validation is once per call, and the contiguity check is a no-op for contiguous input.

CodSpeed currently reports `expanding_min` and `expanding_max` ~13% slower, which does not reproduce: wheels built from the branch tip before and after these commits time identically on the same machine (15.3–15.6 ms both ways, in both directions). CodSpeed's own summary carries a "Different runtime environments detected" warning naming exactly those two benchmarks, and `main`'s baseline run is flagged "CodSpeed harness just leveled up", so the two sides were measured on different harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZFLkBE9pRD3Tuv9xLePJZ
